### PR TITLE
chore: Change repo URLs after rename

### DIFF
--- a/.changeset/quiet-horses-shop.md
+++ b/.changeset/quiet-horses-shop.md
@@ -1,0 +1,7 @@
+---
+"@cronn/playwright-file-snapshots": patch
+"@cronn/vitest-file-snapshots": patch
+"@cronn/lib-file-snapshots": patch
+---
+
+Change repo URLs after rename

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is a monorepo for writing tests with file snapshots, providing integrations
 
 ## Available Integrations
 
-- [vitest-file-snapshots](https://github.com/cronn/vitest-file-snapshots/tree/main/packages/vitest-file-snapshots)
-- [playwright-file-snapshots](https://github.com/cronn/vitest-file-snapshots/tree/main/packages/playwright-file-snapshots)
+- [vitest-file-snapshots](https://github.com/cronn/file-snapshots/tree/main/packages/vitest-file-snapshots)
+- [playwright-file-snapshots](https://github.com/cronn/file-snapshots/tree/main/packages/playwright-file-snapshots)
 
 ## See Also
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/cronn/vitest-file-snapshots"
+    "url": "https://github.com/cronn/file-snapshots"
   },
   "type": "module",
   "scripts": {

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -4,16 +4,16 @@
   "description": "The library agnostic core for testing file snapshots",
   "keywords": ["file snapshots"],
   "bugs": {
-    "url": "https://github.com/cronn/vitest-file-snapshots/issues"
+    "url": "https://github.com/cronn/file-snapshots/issues"
   },
   "author": "cronn",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cronn/vitest-file-snapshots.git",
+    "url": "https://github.com/cronn/file-snapshots.git",
     "directory": "packages/lib-file-snapshots"
   },
-  "homepage": "https://github.com/cronn/vitest-file-snapshots",
+  "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
     "node": ">=22",
     "pnpm": ">=10"

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -4,16 +4,16 @@
   "description": "Write tests with Playwright using file snapshots",
   "keywords": ["playwright", "file snapshots"],
   "bugs": {
-    "url": "https://github.com/cronn/vitest-file-snapshots/issues"
+    "url": "https://github.com/cronn/file-snapshots/issues"
   },
   "author": "cronn",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cronn/vitest-file-snapshots.git",
+    "url": "https://github.com/cronn/file-snapshots.git",
     "directory": "packages/playwright-file-snapshots"
   },
-  "homepage": "https://github.com/cronn/vitest-file-snapshots",
+  "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
     "node": ">=22",
     "pnpm": ">=10"

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -7,10 +7,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cronn/vitest-file-snapshots.git",
+    "url": "https://github.com/cronn/file-snapshots.git",
     "directory": "packages/shared-configs"
   },
-  "homepage": "https://github.com/cronn/vitest-file-snapshots",
+  "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
     "node": ">=22",
     "pnpm": ">=10"

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -4,16 +4,16 @@
   "description": "Write tests with Vitest using file snapshots",
   "keywords": ["vitest", "file snapshots"],
   "bugs": {
-    "url": "https://github.com/cronn/vitest-file-snapshots/issues"
+    "url": "https://github.com/cronn/file-snapshots/issues"
   },
   "author": "cronn",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cronn/vitest-file-snapshots.git",
+    "url": "https://github.com/cronn/file-snapshots.git",
     "directory": "packages/vitest-file-snapshots"
   },
-  "homepage": "https://github.com/cronn/vitest-file-snapshots",
+  "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
     "node": ">=22",
     "pnpm": ">=10"


### PR DESCRIPTION
This PR changes all occurrences of the repo URL after renaming the repo from `vitest-file-snapshots` to `file-snapshots`.