### PR TITLE
feat: Make file name normalization more robust

### DIFF
--- a/.changeset/dark-toes-smell.md
+++ b/.changeset/dark-toes-smell.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Remove more special characters from file names, including quotes and brackets

--- a/.changeset/tall-paws-wonder.md
+++ b/.changeset/tall-paws-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Normalize all whitespace characters in file names

--- a/packages/lib-file-snapshots/src/utils/file.test.ts
+++ b/packages/lib-file-snapshots/src/utils/file.test.ts
@@ -3,21 +3,49 @@ import { describe, expect, test } from "vitest";
 import { normalizeFileName } from "./file";
 
 describe("normalize file name", () => {
-  test.each([" ", ".", ":", "'"])("replaces '%s' by underscore", (value) => {
+  test.each([
+    { name: "whitespace", value: " " },
+    {
+      name: "tab",
+      value: "\t",
+    },
+    { name: "newline", value: "\n" },
+    { name: "dot", value: "." },
+    { name: "colon", value: ":" },
+    { name: "comma", value: "," },
+    { name: "semicolon", value: ";" },
+  ])("replaces $name by underscore", ({ value }) => {
     expect(normalizeFileName(value)).toBe("_");
   });
 
-  test.each([",", "$"])("removes '%s' from test name", (value) => {
+  test.each([
+    "+",
+    "*",
+    "%",
+    "~",
+    "<",
+    ">",
+    "?",
+    "!",
+    "$",
+    "#",
+    "'",
+    '"',
+    "`",
+    "|",
+    "\\",
+    "/",
+    "(",
+    ")",
+    "[",
+    "]",
+    "{",
+    "}",
+  ])("removes '%s' from test name", (value) => {
     expect(normalizeFileName(value)).toBe("");
   });
 
-  test("unwraps quoted value", () => {
-    expect(normalizeFileName(`'value with 1 number'`)).toBe(
-      "value_with_1_number",
-    );
-  });
-
-  test("removes plus from positive zero", () => {
-    expect(normalizeFileName("+0")).toBe("0");
+  test("collapses sequential word delimiters to single underscore", () => {
+    expect(normalizeFileName(" \t_")).toBe("_");
   });
 });

--- a/packages/lib-file-snapshots/src/utils/file.ts
+++ b/packages/lib-file-snapshots/src/utils/file.ts
@@ -4,10 +4,9 @@ const NEW_LINE_SEPARATOR = "\n";
 
 export function normalizeFileName(testName: string): string {
   return testName
-    .replaceAll(/\+0/g, "0") // TODO: extract Vitest-specific replacer to vitest-file-snapshots
-    .replaceAll(/'([\w ]+)'/g, "$1") // TODO: extract Vitest-specific replacer to vitest-file-snapshots
-    .replaceAll(/[ .:']/g, "_")
-    .replaceAll(/[,$]/g, "");
+    .replaceAll(/[+*%~<>?!$#'"`|\\/()[\]{}]/g, "")
+    .replaceAll(/[\s.:,;]+/g, "_")
+    .replaceAll(/_{2,}/g, "_");
 }
 
 export function mkdirRecursive(path: string): void {


### PR DESCRIPTION
This PR introduces the following changes to file name normalization:

- all whitespace characters and delimiters like `.` or `,` are replaced by `_`
- sequential `_` are collapsed to a single `_`
- special characters which are not allowed or hard to read in file names are removed