### PR TITLE
feat: Add index of array item as explicit property to JsonNormalizerContext

### DIFF
--- a/.changeset/clever-eels-rescue.md
+++ b/.changeset/clever-eels-rescue.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Breaking change: Array items now use `index` instead of `key` in `JsonNormalizerContext`

--- a/.changeset/large-rockets-laugh.md
+++ b/.changeset/large-rockets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Add index of array item as explicit property to `JsonNormalizerContext`

--- a/packages/lib-file-snapshots/src/serializers/json-serializer.test.ts
+++ b/packages/lib-file-snapshots/src/serializers/json-serializer.test.ts
@@ -1,5 +1,6 @@
 import { test } from "vitest";
 
+import { isString } from "../utils/guards";
 import { type SerializerTestFn, testSerializer } from "../utils/test";
 
 import {
@@ -112,7 +113,7 @@ test(
       comment: "comment",
     },
     {
-      normalizers: [removeCommentProperty, prefixWithKey, maskNumber],
+      normalizers: [removeCommentProperty, prefixWithContext, maskNumber],
     },
   ),
 );
@@ -133,13 +134,17 @@ function maskNumber(value: unknown): unknown {
   return value;
 }
 
-function prefixWithKey(
+function prefixWithContext(
   value: unknown,
   context: JsonNormalizerContext,
 ): unknown {
-  if (context.key === undefined || typeof value !== "string") {
-    return value;
+  if (isString(value) && context.index !== undefined) {
+    return `${context.index}:${value}`;
   }
 
-  return `${context.key}:${value}`;
+  if (isString(value) && context.key !== undefined) {
+    return `${context.key}:${value}`;
+  }
+
+  return value;
 }

--- a/packages/lib-file-snapshots/src/serializers/json-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/json-serializer.ts
@@ -33,6 +33,7 @@ export type JsonNormalizer = (
 
 export interface JsonNormalizerContext {
   key?: string;
+  index?: number;
 }
 
 export class JsonSerializer implements SnapshotSerializer {
@@ -144,7 +145,7 @@ export class JsonSerializer implements SnapshotSerializer {
 
   private normalizeArray(value: Array<unknown>): JsonValue {
     return value.map((item, index) =>
-      this.normalizeValueRecursive(item, { key: index.toString() }),
+      this.normalizeValueRecursive(item, { index }),
     );
   }
 


### PR DESCRIPTION
This PR adds an explicit property `index` for array items to `JsonNormalizerContext`. Previously, the `index` was exposed as stringified `key`.