### PR TITLE
chore: Use Node.js type stripping instead of jiti

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.17.1
+          node-version: 22.18.0
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.17.1
+          node-version: 22.18.0
           cache: "pnpm"
 
       - name: Install dependencies

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
-    "node": ">=22",
+    "node": ">=22.18",
     "pnpm": ">=10"
   },
   "scripts": {
@@ -47,7 +47,6 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "jiti": "catalog:",
     "prettier": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
-    "node": ">=22",
+    "node": ">=22.18",
     "pnpm": ">=10"
   },
   "scripts": {
@@ -56,7 +56,6 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "jiti": "catalog:",
     "prettier": "catalog:",
     "serve": "catalog:",
     "tsup": "catalog:",

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
-    "node": ">=22",
+    "node": ">=22.18",
     "pnpm": ">=10"
   },
   "scripts": {
@@ -41,7 +41,6 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "jiti": "catalog:",
     "prettier": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/cronn/file-snapshots",
   "engines": {
-    "node": ">=22",
+    "node": ">=22.18",
     "pnpm": ">=10"
   },
   "scripts": {
@@ -53,7 +53,6 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "jiti": "catalog:",
     "prettier": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ catalogs:
     eslint-plugin-unused-imports:
       specifier: 4.1.4
       version: 4.1.4
-    jiti:
-      specifier: 2.5.1
-      version: 2.5.1
     prettier:
       specifier: 3.6.2
       version: 3.6.2
@@ -101,9 +98,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))
-      jiti:
-        specifier: 'catalog:'
-        version: 2.5.1
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -153,9 +147,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))
-      jiti:
-        specifier: 'catalog:'
-        version: 2.5.1
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -192,9 +183,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))
-      jiti:
-        specifier: 'catalog:'
-        version: 2.5.1
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -244,9 +232,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))
-      jiti:
-        specifier: 'catalog:'
-        version: 2.5.1
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -3487,7 +3472,8 @@ snapshots:
 
   javascript-natural-sort@0.7.1: {}
 
-  jiti@2.5.1: {}
+  jiti@2.5.1:
+    optional: true
 
   joycon@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,6 @@ catalog:
   "eslint-plugin-unused-imports": 4.1.4
   "prettier": 3.6.2
   "@trivago/prettier-plugin-sort-imports": 5.2.2
-  "jiti": 2.5.1
   "turbo": 2.5.5
 
 includeWorkspaceRoot: true


### PR DESCRIPTION
Since Node.js 22.18, type stripping is available without additional configuration.