### PR TITLE
feat(vitest): Remove `__tests__` directory from snapshot file path

### DIFF
--- a/.changeset/thick-trees-share.md
+++ b/.changeset/thick-trees-share.md
@@ -1,0 +1,5 @@
+---
+"@cronn/vitest-file-snapshots": minor
+---
+
+Remove `__tests__` directory from snapshot file path

--- a/packages/vitest-file-snapshots/src/matchers/utils.test.ts
+++ b/packages/vitest-file-snapshots/src/matchers/utils.test.ts
@@ -32,6 +32,18 @@ describe("parseTestPath", () => {
     );
   });
 
+  test("removes __tests__ directory from test path", () => {
+    expect(parseTestPath("src/__tests__/feature.test.ts", ".")).toBe(
+      "src/feature",
+    );
+  });
+
+  test("does not remove directory partially matching __tests__ from test path", () => {
+    expect(parseTestPath("src/x__tests__/feature.test.ts", ".")).toBe(
+      "src/x__tests__/feature",
+    );
+  });
+
   test("resolves test path relative to testDir", () => {
     expect(parseTestPath("src/tests/feature.test.ts", "src/tests")).toBe(
       "feature",

--- a/packages/vitest-file-snapshots/src/matchers/utils.ts
+++ b/packages/vitest-file-snapshots/src/matchers/utils.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 
 import { TEST_PATH_SEPARATOR } from "./config";
 
+const TEST_EXTENSION_REGEXP = /\.(test|spec)\.[cm]?[tj]sx?$/;
+
 export function parseTestName(currentTestName: string): Array<string> {
   return currentTestName.split(TEST_PATH_SEPARATOR);
 }
@@ -9,5 +11,5 @@ export function parseTestName(currentTestName: string): Array<string> {
 export function parseTestPath(testPath: string, testDir: string): string {
   const relativeTestPath = path.relative(testDir, testPath);
 
-  return relativeTestPath.replace(/\.(test|spec)\.[cm]?[tj]sx?$/, "");
+  return relativeTestPath.replace(TEST_EXTENSION_REGEXP, "");
 }

--- a/packages/vitest-file-snapshots/src/matchers/utils.ts
+++ b/packages/vitest-file-snapshots/src/matchers/utils.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { TEST_PATH_SEPARATOR } from "./config";
 
+const TESTS_DIR_REGEXP = /(^|\/)__tests__(?=\/)/;
 const TEST_EXTENSION_REGEXP = /\.(test|spec)\.[cm]?[tj]sx?$/;
 
 export function parseTestName(currentTestName: string): Array<string> {
@@ -11,5 +12,7 @@ export function parseTestName(currentTestName: string): Array<string> {
 export function parseTestPath(testPath: string, testDir: string): string {
   const relativeTestPath = path.relative(testDir, testPath);
 
-  return relativeTestPath.replace(TEST_EXTENSION_REGEXP, "");
+  return relativeTestPath
+    .replace(TESTS_DIR_REGEXP, "")
+    .replace(TEST_EXTENSION_REGEXP, "");
 }


### PR DESCRIPTION
This PR automatically removes the `__tests__` directory from snapshot file paths, making the paths less verbose.

`__tests__` is the common directory name used to store tests when they are not colocated with their implementations.