### PR TITLE
feat(playwright): Handle `aria-hidden and role="presentation"

### DIFF
--- a/.changeset/kind-keys-drop.md
+++ b/.changeset/kind-keys-drop.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Exclude elements with `aria-hidden="true"` from DOM Snapshots

--- a/.changeset/wild-rabbits-wish.md
+++ b/.changeset/wild-rabbits-wish.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Ignore elements with `role="presentation"` and `role="none"` in DOM Snapshots

--- a/packages/dom-snapshot/src/snapshots/element.ts
+++ b/packages/dom-snapshot/src/snapshots/element.ts
@@ -1,3 +1,4 @@
+import { booleanAttribute } from "./attribute";
 import { snapshotButton } from "./button";
 import { snapshotChildren } from "./children";
 import { snapshotCombobox, snapshotOption } from "./combobox";
@@ -66,6 +67,11 @@ function snapshotNodeByType(
   }
 
   if (!(node instanceof HTMLElement)) {
+    return null;
+  }
+
+  const ariaHidden = booleanAttribute(node.ariaHidden);
+  if (ariaHidden === true) {
     return null;
   }
 

--- a/packages/dom-snapshot/src/snapshots/role.ts
+++ b/packages/dom-snapshot/src/snapshots/role.ts
@@ -59,6 +59,10 @@ export function resolveElementRole(
   element: SnapshotTargetElement,
 ): ElementRole | undefined {
   const explicitRole = element.role;
+  if (isIgnoredRole(explicitRole)) {
+    return undefined;
+  }
+
   if (
     explicitRole !== null &&
     (hasRoleSpecificSnapshot(explicitRole) || isContainerRole(explicitRole))
@@ -77,6 +81,10 @@ export function resolveElementRole(
   }
 
   return roleResolver(element);
+}
+
+function isIgnoredRole(role: string | null): boolean {
+  return role === "presentation" || role === "none";
 }
 
 export function resolveInputRole(

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/ARIA_snapshot.json
@@ -1,0 +1,3 @@
+{
+  "main": "paragraph 'aria-hidden=false'"
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/ARIA_snapshot.json
@@ -1,3 +1,6 @@
 {
-  "main": "paragraph 'aria-hidden=false'"
+  "main": [
+    "paragraph 'aria-hidden=false'",
+    "text 'role=presentation role=none'"
+  ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/DOM_snapshot.json
@@ -1,0 +1,5 @@
+{
+  "main": {
+    "paragraph": "aria-hidden=false"
+  }
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/accessibility_tree/DOM_snapshot.json
@@ -1,5 +1,9 @@
 {
-  "main": {
-    "paragraph": "aria-hidden=false"
-  }
+  "main": [
+    {
+      "paragraph": "aria-hidden=false"
+    },
+    "role=presentation",
+    "role=none"
+  ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -63,6 +63,13 @@
                 "/url": "/lists"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Accessibility Tree'": {
+                "/url": "/accessibility-tree"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/DOM_snapshot.json
@@ -75,6 +75,14 @@
                 "url": "/lists"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Accessibility Tree",
+                "url": "/accessibility-tree"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/static/accessibility-tree.html
+++ b/packages/playwright-file-snapshots/static/accessibility-tree.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Accessibility Tree</title>
+  </head>
+  <body>
+    <main>
+      <p aria-hidden="true">aria-hidden=true</p>
+      <p aria-hidden="false">aria-hidden=false</p>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/static/accessibility-tree.html
+++ b/packages/playwright-file-snapshots/static/accessibility-tree.html
@@ -8,6 +8,8 @@
     <main>
       <p aria-hidden="true">aria-hidden=true</p>
       <p aria-hidden="false">aria-hidden=false</p>
+      <p role="presentation">role=presentation</p>
+      <p role="none">role=none</p>
     </main>
   </body>
 </html>

--- a/packages/playwright-file-snapshots/static/index.html
+++ b/packages/playwright-file-snapshots/static/index.html
@@ -20,6 +20,7 @@
         </li>
         <li><a href="/headings">Headings</a></li>
         <li><a href="/lists">Lists</a></li>
+        <li><a href="/accessibility-tree">Accessibility Tree</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -72,3 +72,8 @@ test("include combobox options", async ({ page }) => {
     }),
   ).toMatchJsonFile({ name: "collapsed combobox" });
 });
+
+test("accessibility tree", async ({ page }) => {
+  await page.goto("/accessibility-tree");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR extends DOM Snapshots for the following features:

- elements with `aria-hidden=true` are hidden from snapshots, including their descendants
- elements with `role="presentation"` or `role="none"` are hidden from snapshots, but their descendants are visible

This follows the semantics of these attributes regarding the accessibility tree.