### PR TITLE
fix(playwright): Snapshot library is imported using wrong path when installed as dependency

### DIFF
--- a/.changeset/tender-lies-drop.md
+++ b/.changeset/tender-lies-drop.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": patch
+---
+
+Fix: Snapshot library is imported using wrong path when installed as dependency

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -58,6 +58,7 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
+    "package-directory": "catalog:",
     "prettier": "catalog:",
     "serve": "catalog:",
     "tsup": "catalog:",

--- a/packages/playwright-file-snapshots/src/dom-snapshot/proxy.ts
+++ b/packages/playwright-file-snapshots/src/dom-snapshot/proxy.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 import type { Locator, Page } from "@playwright/test";
+import path from "node:path";
+import { packageDirectory } from "package-directory";
 
 export class DomSnapshotProxy {
   private readonly page: Page;
@@ -25,8 +27,21 @@ export class DomSnapshotProxy {
   }
 
   private async loadLibrary(): Promise<void> {
+    const rootDir = await this.resolveRootDir();
     await this.page.addScriptTag({
-      path: "./dist/dom-snapshot.js",
+      path: path.join(rootDir, "dist", "dom-snapshot.js"),
     });
+  }
+
+  private async resolveRootDir(): Promise<string> {
+    const packageDir = await packageDirectory({
+      cwd: import.meta.dirname,
+    });
+
+    if (packageDir === undefined) {
+      throw new Error("Unable to resolve root directory of package");
+    }
+
+    return packageDir;
   }
 }

--- a/packages/playwright-file-snapshots/tsconfig.snapshot.json
+++ b/packages/playwright-file-snapshots/tsconfig.snapshot.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": false,
-    "outDir": "dist/scripts",
-    "declaration": true
-  },
-  "include": ["src/dom-snapshot/snapshot.ts"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     eslint-plugin-unused-imports:
       specifier: 4.2.0
       version: 4.2.0
+    package-directory:
+      specifier: 8.1.0
+      version: 8.1.0
     prettier:
       specifier: 3.6.2
       version: 3.6.2
@@ -180,6 +183,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.2.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
+      package-directory:
+        specifier: 'catalog:'
+        version: 8.1.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1287,6 +1293,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1699,6 +1709,10 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-directory@8.1.0:
+    resolution: {integrity: sha512-qHKRW0pw3lYdZMQVkjDBqh8HlamH/LCww2PH7OWEp4Qrt3SFeYMNpnJrQzlSnGrDD5zGR51XqBh7FnNCdVNEHA==}
+    engines: {node: '>=18'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -3327,6 +3341,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up-simple@1.0.1: {}
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -3694,6 +3710,10 @@ snapshots:
   p-map@2.1.0: {}
 
   p-try@2.2.0: {}
+
+  package-directory@8.1.0:
+    dependencies:
+      find-up-simple: 1.0.1
 
   package-json-from-dist@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ catalog:
   "prettier": 3.6.2
   "@trivago/prettier-plugin-sort-imports": 5.2.2
   "turbo": 2.5.6
+  "package-directory": 8.1.0
 
 includeWorkspaceRoot: true
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "target": "ESNext",
+    "module": "ESNext",
     "strict": true,
     "erasableSyntaxOnly": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
This PR fixes the bug where the DOM Snapshot library is imported using a wrong relative path when installed as dependency. The relative path used previously was resolved relative to the CWD of Playwright, which is not the root directory of the installed playwright-file-snapshots package.