### PR TITLE
feat(playwright): Validate context-dependent element roles

### DIFF
--- a/.changeset/shiny-pets-remain.md
+++ b/.changeset/shiny-pets-remain.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Validate context-dependent element roles in DOM snapshots

--- a/packages/dom-snapshot/src/snapshots/element.ts
+++ b/packages/dom-snapshot/src/snapshots/element.ts
@@ -7,7 +7,7 @@ import { snapshotContainer } from "./container";
 import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
-import { resolveElementRole } from "./role";
+import { parseElementRole } from "./role";
 import { snapshotTextNode } from "./text";
 import type {
   ElementRole,
@@ -75,7 +75,7 @@ function snapshotNodeByType(
     return null;
   }
 
-  const elementRole = resolveElementRole(node);
+  const elementRole = parseElementRole(node);
 
   if (elementRole === undefined) {
     return snapshotChildren(node) ?? null;

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/description_lists/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/description_lists/ARIA_snapshot.json
@@ -17,12 +17,25 @@
     {
       "definition": "Definition 3"
     },
-    "heading 'Incomplete Description List' [level=2]",
+    "heading 'Role-Based Description List' [level=2]",
     {
-      "term": "Term without Description List"
+      "term": "Term"
     },
     {
-      "definition": "Definition without Description List"
+      "definition": "Definition"
+    },
+    "heading 'Incomplete Description List' [level=2]",
+    {
+      "term": "dt outside dl"
+    },
+    {
+      "definition": "dd outside dl"
+    },
+    {
+      "term": "[role=term] outside dl"
+    },
+    {
+      "definition": "[role=definition] outside dl"
     }
   ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/description_lists/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/description_lists/DOM_snapshot.json
@@ -29,11 +29,25 @@
     },
     {
       "heading": {
+        "name": "Role-Based Description List",
+        "level": 2
+      }
+    },
+    {
+      "term": "Term"
+    },
+    {
+      "definition": "Definition"
+    },
+    {
+      "heading": {
         "name": "Incomplete Description List",
         "level": 2
       }
     },
-    "Term without Description List",
-    "Definition without Description List"
+    "dt outside dl",
+    "dd outside dl",
+    "[role=term] outside dl",
+    "[role=definition] outside dl"
   ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/ARIA_snapshot.json
@@ -41,9 +41,23 @@
         }
       ]
     },
+    "heading 'Role-Based List' [level=2]",
+    {
+      "list": [
+        {
+          "listitem": "Item 1"
+        },
+        {
+          "listitem": "Item 2"
+        }
+      ]
+    },
     "heading 'Incomplete List' [level=2]",
     {
-      "listitem": "List Item without List"
+      "listitem": "li outside list"
+    },
+    {
+      "listitem": "[role=listitem] outside list"
     }
   ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/DOM_snapshot.json
@@ -63,10 +63,27 @@
     },
     {
       "heading": {
+        "name": "Role-Based List",
+        "level": 2
+      }
+    },
+    {
+      "list": [
+        {
+          "listitem": "Item 1"
+        },
+        {
+          "listitem": "Item 2"
+        }
+      ]
+    },
+    {
+      "heading": {
         "name": "Incomplete List",
         "level": 2
       }
     },
-    "List Item without List"
+    "li outside list",
+    "[role=listitem] outside list"
   ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/tables/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/tables/ARIA_snapshot.json
@@ -38,17 +38,58 @@
         }
       ]
     },
+    "heading 'Role-Based Table' [level=2]",
+    {
+      "table": [
+        {
+          "row 'Column Header 1 Column Header 2'": [
+            "columnheader 'Column Header 1'",
+            "columnheader 'Column Header 2'"
+          ]
+        },
+        {
+          "rowgroup": [
+            {
+              "row 'Row Header 1 Cell 1'": [
+                "rowheader 'Row Header 1'",
+                "cell 'Cell 1'"
+              ]
+            },
+            {
+              "row 'Row Header 2 Cell 2'": [
+                "rowheader 'Row Header 2'",
+                "cell 'Cell 2'"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "heading 'Incomplete Table' [level=2]",
-    "text 'Table Header without Table Table Body without Table Table Footer without Table Table Row without Table Header Cell without Table Cell without Table'",
+    "text 'thead outside table tbody outside table tfoot outside table tr outside table th outside table td outside table'",
     {
       "table": {
         "rowgroup": {
-          "row 'Header Cell without Row Cell without Row'": [
-            "cell 'Header Cell without Row'",
-            "cell 'Cell without Row'"
+          "row 'th outside row td outside row'": [
+            "cell 'th outside row'",
+            "cell 'td outside row'"
           ]
         }
       }
+    },
+    {
+      "rowgroup": "[role=rowgroup] outside table"
+    },
+    "row '[role=row] outside table'",
+    "columnheader '[role=columnheader] outside table'",
+    "rowheader '[role=rowheader] outside table'",
+    "cell '[role=cell] outside table'",
+    {
+      "table": [
+        "columnheader '[role=columnheader] outside row'",
+        "rowheader '[role=rowheader] outside row'",
+        "cell '[role=cell] outside row'"
+      ]
     },
     "heading 'Grid' [level=2]",
     {
@@ -75,6 +116,21 @@
             }
           ]
         }
+      ]
+    },
+    "heading 'Incomplete Grid' [level=2]",
+    {
+      "rowgroup": "[role=rowgroup] outside grid"
+    },
+    "row '[role=row] outside grid'",
+    "columnheader '[role=columnheader] outside grid'",
+    "rowheader '[role=rowheader] outside grid'",
+    "gridcell '[role=gridcell] outside grid'",
+    {
+      "grid": [
+        "columnheader '[role=columnheader] outside row'",
+        "rowheader '[role=rowheader] outside row'",
+        "gridcell '[role=gridcell] outside row'"
       ]
     }
   ]

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/tables/DOM_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/tables/DOM_snapshot.json
@@ -66,22 +66,78 @@
     },
     {
       "heading": {
+        "name": "Role-Based Table",
+        "level": 2
+      }
+    },
+    {
+      "table": [
+        {
+          "row": [
+            {
+              "columnheader": "Column Header 1"
+            },
+            {
+              "columnheader": "Column Header 2"
+            }
+          ]
+        },
+        {
+          "rowgroup": [
+            {
+              "row": [
+                {
+                  "rowheader": "Row Header 1"
+                },
+                {
+                  "cell": "Cell 1"
+                }
+              ]
+            },
+            {
+              "row": [
+                {
+                  "rowheader": "Row Header 2"
+                },
+                {
+                  "cell": "Cell 2"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": {
         "name": "Incomplete Table",
         "level": 2
       }
     },
-    "Table Header without Table Table Body without Table Table Footer without Table Table Row without Table Header Cell without Table Cell without Table",
+    "thead outside table tbody outside table tfoot outside table tr outside table th outside table td outside table",
     {
       "table": {
         "rowgroup": {
           "row": [
-            "Header Cell without Row",
+            "th outside row",
             {
-              "cell": "Cell without Row"
+              "cell": "td outside row"
             }
           ]
         }
       }
+    },
+    "[role=rowgroup] outside table",
+    "[role=row] outside table",
+    "[role=columnheader] outside table",
+    "[role=rowheader] outside table",
+    "[role=cell] outside table",
+    {
+      "table": [
+        "[role=columnheader] outside row",
+        "[role=rowheader] outside row",
+        "[role=cell] outside row"
+      ]
     },
     {
       "heading": {
@@ -125,6 +181,24 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "heading": {
+        "name": "Incomplete Grid",
+        "level": 2
+      }
+    },
+    "[role=rowgroup] outside grid",
+    "[role=row] outside grid",
+    "[role=columnheader] outside grid",
+    "[role=rowheader] outside grid",
+    "[role=gridcell] outside grid",
+    {
+      "grid": [
+        "[role=columnheader] outside row",
+        "[role=rowheader] outside row",
+        "[role=gridcell] outside row"
       ]
     }
   ]

--- a/packages/playwright-file-snapshots/static/description-lists.html
+++ b/packages/playwright-file-snapshots/static/description-lists.html
@@ -18,9 +18,18 @@
         </dl>
       </section>
       <section>
+        <h2>Role-Based Description List</h2>
+        <dl>
+          <div role="term">Term</div>
+          <div role="definition">Definition</div>
+        </dl>
+      </section>
+      <section>
         <h2>Incomplete Description List</h2>
-        <dt>Term without Description List</dt>
-        <dd>Definition without Description List</dd>
+        <dt>dt outside dl</dt>
+        <dd>dd outside dl</dd>
+        <div role="term">[role=term] outside dl</div>
+        <div role="definition">[role=definition] outside dl</div>
       </section>
     </main>
   </body>

--- a/packages/playwright-file-snapshots/static/lists.html
+++ b/packages/playwright-file-snapshots/static/lists.html
@@ -34,8 +34,16 @@
         </ol>
       </section>
       <section>
+        <h2>Role-Based List</h2>
+        <div role="list">
+          <div role="listitem">Item 1</div>
+          <div role="listitem">Item 2</div>
+        </div>
+      </section>
+      <section>
         <h2>Incomplete List</h2>
-        <li>List Item without List</li>
+        <li>li outside list</li>
+        <div role="listitem">[role=listitem] outside list</div>
       </section>
     </main>
   </body>

--- a/packages/playwright-file-snapshots/static/tables.html
+++ b/packages/playwright-file-snapshots/static/tables.html
@@ -35,25 +35,54 @@
         </table>
       </section>
       <section>
+        <h2>Role-Based Table</h2>
+        <div role="table">
+          <div role="row">
+            <div role="columnheader">Column Header 1</div>
+            <div role="columnheader">Column Header 2</div>
+          </div>
+          <div role="rowgroup">
+            <div role="row">
+              <div role="rowheader">Row Header 1</div>
+              <div role="cell">Cell 1</div>
+            </div>
+            <div role="row">
+              <div role="rowheader">Row Header 2</div>
+              <div role="cell">Cell 2</div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section>
         <h2>Incomplete Table</h2>
         <thead>
-          Table Header without Table
+          thead outside table
         </thead>
         <tbody>
-          Table Body without Table
+          tbody outside table
         </tbody>
         <tfoot>
-          Table Footer without Table
+          tfoot outside table
         </tfoot>
         <tr>
-          Table Row without Table
+          tr outside table
         </tr>
-        <th>Header Cell without Table</th>
-        <td>Cell without Table</td>
+        <th>th outside table</th>
+        <td>td outside table</td>
         <table>
-          <th>Header Cell without Row</th>
-          <td>Cell without Row</td>
+          <th>th outside row</th>
+          <td>td outside row</td>
         </table>
+        <div role="rowgroup">[role=rowgroup] outside table</div>
+        <div role="row">[role=row] outside table</div>
+        <div role="columnheader">[role=columnheader] outside table</div>
+        <div role="rowheader">[role=rowheader] outside table</div>
+        <div role="cell">[role=cell] outside table</div>
+        <div role="table">
+          <div role="columnheader">[role=columnheader] outside row</div>
+          <div role="rowheader">[role=rowheader] outside row</div>
+          <div role="cell">[role=cell] outside row</div>
+        </div>
       </section>
       <section>
         <h2>Grid</h2>
@@ -72,6 +101,19 @@
               <div role="gridcell">Grid Cell 2</div>
             </div>
           </div>
+        </div>
+      </section>
+      <section>
+        <h2>Incomplete Grid</h2>
+        <div role="rowgroup">[role=rowgroup] outside grid</div>
+        <div role="row">[role=row] outside grid</div>
+        <div role="columnheader">[role=columnheader] outside grid</div>
+        <div role="rowheader">[role=rowheader] outside grid</div>
+        <div role="gridcell">[role=gridcell] outside grid</div>
+        <div role="grid">
+          <div role="columnheader">[role=columnheader] outside row</div>
+          <div role="rowheader">[role=rowheader] outside row</div>
+          <div role="gridcell">[role=gridcell] outside row</div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
Previously, the context of an element was validated for some table elements like `<tr>` or `<td>`, which need to be within a `<table>`. This PR changes the validation to be based on the element role, such that it's independent on whether a semantical HTML element or a generic element with a `role` attribute is used.

Note: The validation of HTML specific elements is less strict now. For example, `<tr>` is now allowed to be within `<div role="grid">`. After resolving the roles, it is a `row` within a `grid`, which is valid in an accessibility tree, but not valid in HTML. This was a conscious decision to reduce the complexity. In the end, the snapshot library should be no replacement for existing validators which fully implement the respective standards.