### PR TITLE
fix(playwright): Default `validationDir` and `outputDir` depend on CWD

### DIFF
--- a/.changeset/brown-spoons-itch.md
+++ b/.changeset/brown-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Fix: Default `validationDir` and `outputDir` depend on CWD

--- a/.changeset/wide-humans-wink.md
+++ b/.changeset/wide-humans-wink.md
@@ -1,0 +1,7 @@
+---
+"@cronn/playwright-file-snapshots": minor
+"@cronn/vitest-file-snapshots": minor
+"@cronn/lib-file-snapshots": minor
+---
+
+Enable defining default `validationDir` and `outputDir` with framework-dependent absolute path

--- a/packages/lib-file-snapshots/src/matcher/validation-file-matcher.test.ts
+++ b/packages/lib-file-snapshots/src/matcher/validation-file-matcher.test.ts
@@ -54,7 +54,7 @@ test("when validation file is missing, creates validation file with marker", asy
   const matcher = new ValidationFileMatcher({
     validationDir: path.join(tmpDir, "validation"),
     outputDir: path.join(tmpDir, "output"),
-    filePath: "./src/tests/feature/test",
+    filePath: "src/tests/feature/test",
     serializer: new TextSerializer(),
   });
   expect(matcher.isValidationFileMissing).toBe(true);
@@ -73,7 +73,9 @@ test("when validation file is missing, creates validation file with marker", asy
 
 test("when validation file exists, does not recreate validation file", async (context) => {
   const matcher = new ValidationFileMatcher({
-    filePath: "./src/tests/feature/test",
+    validationDir: "data/test/validation",
+    outputDir: "data/test/output",
+    filePath: "src/tests/feature/test",
     serializer: new JsonSerializer(),
   });
   expect(matcher.isValidationFileMissing).toBe(false);
@@ -90,7 +92,9 @@ test("when validation file exists, does not recreate validation file", async (co
 test("when serializer does not support value, throws error", () => {
   expect(() =>
     new ValidationFileMatcher({
-      filePath: "./src/tests/feature.test.ts",
+      validationDir: "data/test/validation",
+      outputDir: "data/test/output",
+      filePath: "src/tests/feature.test.ts",
       serializer: new FailingSerializer(),
     }).matchFileSnapshot(["value"]),
   ).toThrowError();

--- a/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
+++ b/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
@@ -55,13 +55,12 @@ export class ValidationFileMatcher {
   private buildFilePaths(
     config: ValidationFileMatcherConfig,
   ): MatcherFilePaths {
-    const validationDir = config.validationDir ?? "data/test/validation";
-    const outputDir = config.outputDir ?? "data/test/output";
-    const filePathWithExtenion = `${config.filePath}.${config.serializer.fileExtension}`;
+    const { validationDir, outputDir, filePath, serializer } = config;
+    const filePathWithExtension = `${filePath}.${serializer.fileExtension}`;
 
     return {
-      outputFilePath: path.join(outputDir, filePathWithExtenion),
-      validationFilePath: path.join(validationDir, filePathWithExtenion),
+      outputFilePath: path.join(outputDir, filePathWithExtension),
+      validationFilePath: path.join(validationDir, filePathWithExtension),
     };
   }
 

--- a/packages/lib-file-snapshots/src/types/matcher.ts
+++ b/packages/lib-file-snapshots/src/types/matcher.ts
@@ -3,17 +3,13 @@ import type { SnapshotSerializer } from "./serializer";
 export interface ValidationFileMatcherConfig {
   /**
    * Directory in which golden masters are stored
-   *
-   * @default "data/test/validation"
    */
-  validationDir?: string;
+  validationDir: string;
 
   /**
    * Directory in which file snapshots from test runs are stored
-   *
-   * @default "data/test/output"
    */
-  outputDir?: string;
+  outputDir: string;
 
   /**
    * The full path to the snapshot file

--- a/packages/playwright-file-snapshots/src/dom-snapshot/proxy.ts
+++ b/packages/playwright-file-snapshots/src/dom-snapshot/proxy.ts
@@ -1,7 +1,8 @@
 /// <reference lib="dom" />
 import type { Locator, Page } from "@playwright/test";
 import path from "node:path";
-import { packageDirectory } from "package-directory";
+
+import { resolvePackageRootDir } from "../utils/file";
 
 export class DomSnapshotProxy {
   private readonly page: Page;
@@ -27,21 +28,9 @@ export class DomSnapshotProxy {
   }
 
   private async loadLibrary(): Promise<void> {
-    const rootDir = await this.resolveRootDir();
+    const rootDir = await resolvePackageRootDir(import.meta.dirname);
     await this.page.addScriptTag({
       path: path.join(rootDir, "dist", "dom-snapshot.js"),
     });
-  }
-
-  private async resolveRootDir(): Promise<string> {
-    const packageDir = await packageDirectory({
-      cwd: import.meta.dirname,
-    });
-
-    if (packageDir === undefined) {
-      throw new Error("Unable to resolve root directory of package");
-    }
-
-    return packageDir;
   }
 }

--- a/packages/playwright-file-snapshots/src/matchers/file-matcher.ts
+++ b/packages/playwright-file-snapshots/src/matchers/file-matcher.ts
@@ -16,6 +16,7 @@ import {
   resolveNameAsFile,
 } from "@cronn/lib-file-snapshots";
 
+import { ensureAbsolutePath } from "../utils/file";
 import { waitForTimer } from "../utils/timer";
 
 import {
@@ -52,8 +53,8 @@ export async function matchValidationFile(
   }
 
   const {
-    validationDir,
-    outputDir,
+    validationDir = "data/test/validation",
+    outputDir = "data/test/output",
     resolveFilePath: configuredFilePathResolver,
   } = config;
   const { name, resolveFilePath: localFilePathResolver } = options;
@@ -61,12 +62,12 @@ export async function matchValidationFile(
     localFilePathResolver ?? configuredFilePathResolver ?? resolveNameAsFile;
 
   return await test.step(MATCHER_STEP_TITLE, async (stepTestInfo) => {
-    const { updateSnapshots } = parseTestInfo(test.info());
+    const { rootDir, updateSnapshots } = await parseTestInfo(test.info());
     const { testPath, titlePath } = parseTestStepInfo(stepTestInfo);
     const filePath = resolveFilePath({ testPath, titlePath, name });
     const matcher = new ValidationFileMatcher({
-      validationDir,
-      outputDir,
+      validationDir: ensureAbsolutePath(validationDir, rootDir),
+      outputDir: ensureAbsolutePath(outputDir, rootDir),
       filePath,
       serializer,
     });

--- a/packages/playwright-file-snapshots/src/matchers/utils.test.ts
+++ b/packages/playwright-file-snapshots/src/matchers/utils.test.ts
@@ -1,6 +1,8 @@
 import type { FullConfig } from "@playwright/test";
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 
+import type { ParsedTestInfo } from "./utils";
 import {
   parseTestInfo,
   parseTestPath,
@@ -37,10 +39,25 @@ function createConfig(values: Partial<FullConfig> = {}): FullConfig {
 }
 
 describe("parseTestInfo", () => {
-  test("returns parsed test info", () => {
-    expect(
-      parseTestInfo({ config: createConfig({ updateSnapshots: "changed" }) }),
-    ).toStrictEqual({ updateSnapshots: true });
+  test("returns parsed test info", async () => {
+    function normalizeRootDir(testInfo: ParsedTestInfo): ParsedTestInfo {
+      return {
+        ...testInfo,
+        rootDir: path.basename(testInfo.rootDir),
+      };
+    }
+
+    await expect(
+      parseTestInfo({
+        config: createConfig({
+          rootDir: import.meta.url,
+          updateSnapshots: "changed",
+        }),
+      }).then(normalizeRootDir),
+    ).resolves.toStrictEqual({
+      rootDir: "playwright-file-snapshots",
+      updateSnapshots: true,
+    });
   });
 });
 

--- a/packages/playwright-file-snapshots/src/matchers/utils.ts
+++ b/packages/playwright-file-snapshots/src/matchers/utils.ts
@@ -1,14 +1,22 @@
 import type { TestInfo, TestStepInfo } from "@playwright/test";
 
+import { resolvePackageRootDir } from "../utils/file";
+
 type RawTestInfo = Pick<TestInfo, "config">;
 
-interface ParsedTestInfo {
+export interface ParsedTestInfo {
+  rootDir: string;
   updateSnapshots: boolean;
 }
 
-export function parseTestInfo(testInfo: RawTestInfo): ParsedTestInfo {
+export async function parseTestInfo(
+  testInfo: RawTestInfo,
+): Promise<ParsedTestInfo> {
+  const { config } = testInfo;
+
   return {
-    updateSnapshots: parseUpdateSnapshots(testInfo.config.updateSnapshots),
+    rootDir: await resolvePackageRootDir(config.rootDir),
+    updateSnapshots: parseUpdateSnapshots(config.updateSnapshots),
   };
 }
 

--- a/packages/playwright-file-snapshots/src/utils/file.test.ts
+++ b/packages/playwright-file-snapshots/src/utils/file.test.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { ensureAbsolutePath, resolvePackageRootDir } from "./file";
+import { createTmpDir } from "./test";
+
+describe("resolvePackageRootDir", () => {
+  test("returns root directory of package", async () => {
+    const packageRootDir = await resolvePackageRootDir(import.meta.dirname);
+    expect(path.basename(packageRootDir)).toBe("playwright-file-snapshots");
+  });
+
+  test("when no package root exists, throws error", async () => {
+    const tmpDir = createTmpDir();
+    await expect(() => resolvePackageRootDir(tmpDir)).rejects.toThrowError();
+  });
+});
+
+describe("ensureAbsolutePath", () => {
+  const absoluteDir = import.meta.dirname;
+
+  test("when path is absolute, returns original path", () => {
+    expect(ensureAbsolutePath(absoluteDir, "/")).toBe(absoluteDir);
+  });
+
+  test("when path is relative, prepends rootDir to original path", () => {
+    const relativeDir = "relative/path/to/dir";
+    expect(ensureAbsolutePath(relativeDir, absoluteDir)).toBe(
+      path.join(absoluteDir, relativeDir),
+    );
+  });
+});

--- a/packages/playwright-file-snapshots/src/utils/file.ts
+++ b/packages/playwright-file-snapshots/src/utils/file.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { packageDirectory } from "package-directory";
+
+export async function resolvePackageRootDir(fromDir: string): Promise<string> {
+  const packageDir = await packageDirectory({
+    cwd: fromDir,
+  });
+
+  if (packageDir === undefined) {
+    throw new Error("Unable to resolve root directory of package");
+  }
+
+  return packageDir;
+}
+
+export function ensureAbsolutePath(baseDir: string, rootDir: string): string {
+  if (path.isAbsolute(baseDir)) {
+    return baseDir;
+  }
+
+  return path.join(rootDir, baseDir);
+}

--- a/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
+++ b/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
@@ -42,8 +42,8 @@ export function matchValidationFile(
   }
 
   const {
-    validationDir,
-    outputDir,
+    validationDir = "data/test/validation",
+    outputDir = "data/test/output",
     testDir = ".",
     resolveFilePath: configuredFilePathResolver,
   } = config;


### PR DESCRIPTION
This PR moves the definition of the default values for `validationDir` and `outputDir` from `lib-file-snapshots` to the framework-specific libraries. This enables to define them as absolute paths in `playwright-file-snapshots`, improving the compatibility with the Playwright VS Code extension, which uses the workspace root instead of the package root as CWD in monorepos.