### PR TITLE
ci: Enable stricter pnpm settings for increased security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.15.1
+          version: 10.16.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.15.1
+          version: 10.16.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "url": "https://github.com/cronn/file-snapshots"
   },
   "type": "module",
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.16.1",
   "engines": {
     "node": ">=22.18",
-    "pnpm": ">=10"
+    "pnpm": ">=10.16"
   },
   "scripts": {
     "format:check": "prettier . --check",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "packageManager": "pnpm@10.16.1",
   "engines": {
-    "node": ">=22.18",
+    "node": ">=22.18 <23",
     "pnpm": ">=10.16"
   },
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,8 @@ catalog:
 
 includeWorkspaceRoot: true
 
+strictDepBuilds: true
+
 ignoredBuiltDependencies:
   - esbuild
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,5 @@ includeWorkspaceRoot: true
 
 ignoredBuiltDependencies:
   - esbuild
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
In light of the recent attacks on npm packages, pnpm v10.16 introduced the setting [`minimumReleaseAge` ](https://pnpm.io/settings#minimumreleaseage) to delay the installation of newly published versions and reduce the risk of installing compromised packages.

In addition. the setting `strictDepBuilds` enforces reviewing new postinstall script from dependencies.