### PR TITLE
feat: Add option `fileExtension` for text snapshots

### DIFF
--- a/.changeset/ready-pets-shout.md
+++ b/.changeset/ready-pets-shout.md
@@ -1,0 +1,5 @@
+---
+"@cronn/vitest-file-snapshots": minor
+---
+
+Add option `fileExtension` to matcher `toMatchTextFile`

--- a/.changeset/slow-coins-pay.md
+++ b/.changeset/slow-coins-pay.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Add option `fileExtension` to `TextSerializer`

--- a/.changeset/some-yaks-pull.md
+++ b/.changeset/some-yaks-pull.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Add option `fileExtension` to matcher `toMatchTextFile`

--- a/packages/lib-file-snapshots/src/serializers/__snapshots__/text-serializer/custom_file_extension.md
+++ b/packages/lib-file-snapshots/src/serializers/__snapshots__/text-serializer/custom_file_extension.md
@@ -1,0 +1,1 @@
+# Heading

--- a/packages/lib-file-snapshots/src/serializers/text-serializer.test.ts
+++ b/packages/lib-file-snapshots/src/serializers/text-serializer.test.ts
@@ -39,3 +39,8 @@ function maskNumber(value: string): string {
 function removeComment(value: string): string {
   return value.replaceAll(/comment/g, "");
 }
+
+test(
+  "custom file extension",
+  testSerializer(new TextSerializer({ fileExtension: "md" }), "# Heading"),
+);

--- a/packages/lib-file-snapshots/src/serializers/text-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/text-serializer.ts
@@ -7,17 +7,25 @@ export interface TextSerializerOptions {
    * Custom normalizers to apply before serialization
    */
   normalizers?: Array<TextNormalizer>;
+
+  /**
+   * File extension used for storing the text file
+   *
+   * @default "txt"
+   */
+  fileExtension?: string;
 }
 
 export type TextNormalizer = (value: string) => string;
 
 export class TextSerializer implements SnapshotSerializer {
-  public readonly fileExtension = "txt";
+  public readonly fileExtension;
 
   private readonly normalizers: Array<TextNormalizer>;
 
   public constructor(options: TextSerializerOptions = {}) {
     this.normalizers = options.normalizers ?? [];
+    this.fileExtension = options.fileExtension ?? "txt";
   }
 
   public canSerialize(value: unknown): value is string {

--- a/packages/playwright-file-snapshots/README.md
+++ b/packages/playwright-file-snapshots/README.md
@@ -329,3 +329,9 @@ await expect(value).toMatchTextFile({
 | Option                             | Default Value | Description                                                                 |
 | ---------------------------------- | ------------- | --------------------------------------------------------------------------- |
 | `includeUndefinedObjectProperties` | `false`       | Serializes `undefined` properties in objects. By default, they are omitted. |
+
+#### Text Snapshot Options
+
+| Option          | Default Value | Description                                    |
+| --------------- | ------------- | ---------------------------------------------- |
+| `fileExtension` | `txt`         | File extension used for storing the text file. |

--- a/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/applies_custom_file_extension.md
+++ b/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/applies_custom_file_extension.md
@@ -1,0 +1,1 @@
+# Heading

--- a/packages/playwright-file-snapshots/src/matchers/define-expect.ts
+++ b/packages/playwright-file-snapshots/src/matchers/define-expect.ts
@@ -49,11 +49,11 @@ export function defineValidationFileExpect(
     actual: unknown,
     options: PlaywrightMatchTextFileOptions = {},
   ): Promise<MatcherReturnType> {
-    const { normalizers, ...snapshotOptions } = options;
+    const { normalizers, fileExtension, ...snapshotOptions } = options;
     return await matchValidationFile({
       actual,
       matcherName: "toMatchTextFile",
-      serializer: new TextSerializer({ normalizers }),
+      serializer: new TextSerializer({ normalizers, fileExtension }),
       config: snapshotConfig,
       options: snapshotOptions,
       matcherState: this,

--- a/packages/playwright-file-snapshots/src/matchers/types.ts
+++ b/packages/playwright-file-snapshots/src/matchers/types.ts
@@ -80,6 +80,13 @@ export interface PlaywrightMatchTextFileOptions
    * Custom normalizers to apply before serialization
    */
   normalizers?: Array<TextNormalizer>;
+
+  /**
+   * File extension used for storing the snapshot file
+   *
+   * @default "txt"
+   */
+  fileExtension?: string;
 }
 
 export interface PlaywrightMatchJsonFileOptions

--- a/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
+++ b/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
@@ -27,3 +27,9 @@ test("applies custom file path resolver", async () => {
     resolveFilePath: testFilePathResolver,
   });
 });
+
+test("applies custom file extension", async () => {
+  await expect("# Heading").toMatchTextFile({
+    fileExtension: "md",
+  });
+});

--- a/packages/vitest-file-snapshots/README.md
+++ b/packages/vitest-file-snapshots/README.md
@@ -254,3 +254,9 @@ expect(value).toMatchJsonFile({
 | Option                             | Default Value | Description                                                                 |
 | ---------------------------------- | ------------- | --------------------------------------------------------------------------- |
 | `includeUndefinedObjectProperties` | `false`       | Serializes `undefined` properties in objects. By default, they are omitted. |
+
+#### Text Snapshot Options
+
+| Option          | Default Value | Description                                    |
+| --------------- | ------------- | ---------------------------------------------- |
+| `fileExtension` | `txt`         | File extension used for storing the text file. |

--- a/packages/vitest-file-snapshots/data/test/validation/src/matchers/register-matchers/text_file_matcher/applies_custom_file_extension.md
+++ b/packages/vitest-file-snapshots/data/test/validation/src/matchers/register-matchers/text_file_matcher/applies_custom_file_extension.md
@@ -1,0 +1,1 @@
+# Heading

--- a/packages/vitest-file-snapshots/src/matchers/register-matchers.test.ts
+++ b/packages/vitest-file-snapshots/src/matchers/register-matchers.test.ts
@@ -122,6 +122,12 @@ describe("text file matcher", () => {
       resolveFilePath: testFilePathResolver,
     });
   });
+
+  test("applies custom file extension", () => {
+    expect("# Heading").toMatchTextFile({
+      fileExtension: "md",
+    });
+  });
 });
 
 export function testFilePathResolver(params: FilePathResolverParams): string {

--- a/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
+++ b/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
@@ -44,10 +44,10 @@ export function registerValidationFileMatchers(
     received: unknown,
     options: VitestMatchTextFileOptions = {},
   ): ExpectationResult {
-    const { normalizers, ...snapshotOptions } = options;
+    const { normalizers, fileExtension, ...snapshotOptions } = options;
     return matchValidationFile({
       received,
-      serializer: new TextSerializer({ normalizers }),
+      serializer: new TextSerializer({ normalizers, fileExtension }),
       config: snapshotConfig,
       options: snapshotOptions,
       matcherState: this,

--- a/packages/vitest-file-snapshots/src/matchers/types.ts
+++ b/packages/vitest-file-snapshots/src/matchers/types.ts
@@ -33,6 +33,13 @@ export interface VitestMatchTextFileOptions
    * Custom normalizers to apply before serialization
    */
   normalizers?: Array<TextNormalizer>;
+
+  /**
+   * File extension used for storing the snapshot file
+   *
+   * @default "txt"
+   */
+  fileExtension?: string;
 }
 
 export interface VitestMatchJsonFileOptions


### PR DESCRIPTION
This PR adds the option `fileExtension` to the `toMatchTextFile` matchers. This makes the matchers more flexible, enabling the use of custom file formats which are not yet supported in the libraries, like Markdown or YAML:

Example:
```ts
expect(serializeAsMarkdown(value)).toMatchTextFile({ fileExtension: "md" });
```