### PR TITLE
feat(playwright): Add element snapshot for role `alertdialog`

### DIFF
--- a/.changeset/flat-wolves-wonder.md
+++ b/.changeset/flat-wolves-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Add element snapshot for role `alertdialog`

--- a/packages/element-snapshot/src/snapshots/dialog.ts
+++ b/packages/element-snapshot/src/snapshots/dialog.ts
@@ -5,16 +5,27 @@ import { resolveAccessibleName } from "./name";
 import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
 
 export interface DialogSnapshot
-  extends GenericElementSnapshot<"dialog", DialogAttributes> {}
+  extends GenericElementSnapshot<DialogRole, DialogAttributes> {}
+
+export type DialogRole = "dialog" | "alertdialog";
 
 interface DialogAttributes {
   description?: string;
   modal?: boolean;
 }
 
-export function snapshotDialog(element: SnapshotTargetElement): DialogSnapshot {
+type DialogSnapshotFn = (element: SnapshotTargetElement) => DialogSnapshot;
+
+export function snapshotDialogWithRole(role: DialogRole): DialogSnapshotFn {
+  return (element) => snapshotDialog(role, element);
+}
+
+function snapshotDialog(
+  role: DialogRole,
+  element: SnapshotTargetElement,
+): DialogSnapshot {
   return {
-    role: "dialog",
+    role,
     name: resolveAccessibleName(element, false),
     attributes: {
       description: resolveDescription(element),

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -4,7 +4,7 @@ import { snapshotChildren } from "./children";
 import { snapshotCombobox, snapshotOption } from "./combobox";
 import type { ContainerRole } from "./container";
 import { snapshotContainer } from "./container";
-import { snapshotDialog } from "./dialog";
+import { snapshotDialogWithRole } from "./dialog";
 import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
@@ -37,7 +37,8 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   slider: snapshotInput,
   spinbutton: snapshotInput,
   textbox: snapshotInput,
-  dialog: snapshotDialog,
+  dialog: snapshotDialogWithRole("dialog"),
+  alertdialog: snapshotDialogWithRole("alertdialog"),
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/snapshots/types.ts
+++ b/packages/element-snapshot/src/snapshots/types.ts
@@ -1,7 +1,7 @@
 import type { ButtonSnapshot } from "./button";
 import type { ComboboxSnapshot, OptionSnapshot } from "./combobox";
 import type { ContainerRole, ContainerSnapshot } from "./container";
-import type { DialogSnapshot } from "./dialog";
+import type { DialogRole, DialogSnapshot } from "./dialog";
 import type { HeadingSnapshot } from "./heading";
 import type { InputRole, InputSnapshot } from "./input";
 import type { LinkSnapshot } from "./link";
@@ -20,9 +20,9 @@ export type ElementRole =
   | "link"
   | "button"
   | "option"
-  | "dialog"
   | ContainerRole
-  | InputRole;
+  | InputRole
+  | DialogRole;
 
 export type NodeSnapshot = ElementSnapshot | TextSnapshot;
 

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/dialogs/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/dialogs/ARIA_snapshot.json
@@ -1,14 +1,20 @@
 {
   "main": [
     "heading 'Dialogs' [level=1]",
+    "heading 'Dialog' [level=2]",
     {
       "dialog 'Dialog Title'": [
         "heading 'Dialog Title' [level=2]",
         "paragraph 'Description Text'"
       ]
     },
+    "heading 'Modal Dialog' [level=2]",
     {
       "dialog 'Modal Dialog Title'": "heading 'Modal Dialog Title' [level=2]"
+    },
+    "heading 'Alert Dialog' [level=2]",
+    {
+      "alertdialog 'Alert Dialog Title'": "heading 'Alert Dialog Title' [level=2]"
     }
   ]
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/dialogs/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/dialogs/Element_snapshot.json
@@ -7,6 +7,12 @@
       }
     },
     {
+      "heading": {
+        "name": "Dialog",
+        "level": 2
+      }
+    },
+    {
       "dialog": {
         "name": "Dialog Title",
         "description": "Description Text",
@@ -24,6 +30,12 @@
       }
     },
     {
+      "heading": {
+        "name": "Modal Dialog",
+        "level": 2
+      }
+    },
+    {
       "dialog": {
         "name": "Modal Dialog Title",
         "modal": true,
@@ -31,6 +43,25 @@
           {
             "heading": {
               "name": "Modal Dialog Title",
+              "level": 2
+            }
+          }
+        ]
+      }
+    },
+    {
+      "heading": {
+        "name": "Alert Dialog",
+        "level": 2
+      }
+    },
+    {
+      "alertdialog": {
+        "name": "Alert Dialog Title",
+        "children": [
+          {
+            "heading": {
+              "name": "Alert Dialog Title",
               "level": 2
             }
           }

--- a/packages/playwright-file-snapshots/test-pages/dialogs.html
+++ b/packages/playwright-file-snapshots/test-pages/dialogs.html
@@ -7,17 +7,29 @@
   <body>
     <main>
       <h1>Dialogs</h1>
-      <div
-        role="dialog"
-        aria-labelledby="dialogTitle"
-        aria-describedby="dialogDescription"
-      >
-        <h2 id="dialogTitle">Dialog Title</h2>
-        <p id="dialogDescription">Description Text</p>
-      </div>
-      <div role="dialog" aria-labelledby="modalDialogTitle" aria-modal="true">
-        <h2 id="modalDialogTitle">Modal Dialog Title</h2>
-      </div>
+      <section>
+        <h2>Dialog</h2>
+        <div
+          role="dialog"
+          aria-labelledby="dialogTitle"
+          aria-describedby="dialogDescription"
+        >
+          <h2 id="dialogTitle">Dialog Title</h2>
+          <p id="dialogDescription">Description Text</p>
+        </div>
+      </section>
+      <section>
+        <h2>Modal Dialog</h2>
+        <div role="dialog" aria-labelledby="modalDialogTitle" aria-modal="true">
+          <h2 id="modalDialogTitle">Modal Dialog Title</h2>
+        </div>
+      </section>
+      <section>
+        <h2>Alert Dialog</h2>
+        <div role="alertdialog" aria-labelledby="alertDialogTitle">
+          <h2 id="alertDialogTitle">Alert Dialog Title</h2>
+        </div>
+      </section>
     </main>
   </body>
 </html>


### PR DESCRIPTION
This PR adds support for snapshotting element with `role="alertdialog"`.

`alertdialog` is a special variant of a `dialog`, so the existing snapshot can be reused with a different role, see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role. 