### PR TITLE
feat(playwright): Add element snapshot for role `alert`

### DIFF
--- a/.changeset/quick-pets-care.md
+++ b/.changeset/quick-pets-care.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Add element snapshot for role `alert`

--- a/packages/element-snapshot/src/snapshots/container.ts
+++ b/packages/element-snapshot/src/snapshots/container.ts
@@ -26,6 +26,7 @@ const CONTAINER_ROLES = [
   "rowheader",
   "cell",
   "gridcell",
+  "alert",
 ] as const;
 
 export interface ContainerSnapshot

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/live_regions/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/live_regions/ARIA_snapshot.json
@@ -1,0 +1,9 @@
+{
+  "main": [
+    "heading 'Live Regions' [level=1]",
+    "heading 'Alert' [level=2]",
+    {
+      "alert": "Alert Message"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/live_regions/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/live_regions/Element_snapshot.json
@@ -1,0 +1,19 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Live Regions",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Alert",
+        "level": 2
+      }
+    },
+    {
+      "alert": "Alert Message"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -98,6 +98,13 @@
                 "/url": "/accessibility-tree"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Live Regions'": {
+                "/url": "/live-regions"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -115,6 +115,14 @@
                 "url": "/accessibility-tree"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Live Regions",
+                "url": "/live-regions"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -25,6 +25,7 @@
         <li><a href="/description-lists">Description Lists</a></li>
         <li><a href="/tables">Tables</a></li>
         <li><a href="/accessibility-tree">Accessibility Tree</a></li>
+        <li><a href="/live-regions">Live Regions</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/test-pages/live-regions.html
+++ b/packages/playwright-file-snapshots/test-pages/live-regions.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Live Regions</title>
+  </head>
+  <body>
+    <main>
+      <h1>Live Regions</h1>
+      <section>
+        <h2>Alert</h2>
+        <div role="alert">Alert Message</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -113,3 +113,8 @@ test("dialogs", async ({ page }) => {
   await page.goto("/dialogs");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("live regions", async ({ page }) => {
+  await page.goto("/live-regions");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snapshotting elements with `role="alert"`.

For further details, see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role.