### PR TITLE
feat(playwright): Filter visually hidden elements from snapshot

### DIFF
--- a/.changeset/nasty-crabs-hug.md
+++ b/.changeset/nasty-crabs-hug.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Filter visually hidden elements from element snapshot

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -70,12 +70,7 @@ function snapshotNodeByType(
     return snapshotTextNode(node);
   }
 
-  if (!isSupportedElement(node)) {
-    return null;
-  }
-
-  const ariaHidden = booleanAttribute(node.ariaHidden);
-  if (ariaHidden === true) {
+  if (!isSupportedElement(node) || isHiddenElement(node)) {
     return null;
   }
 
@@ -118,4 +113,28 @@ export function hasRoleSpecificSnapshot(
   role: string,
 ): role is NonContainerElementRole {
   return role in ROLE_SNAPSHOTS;
+}
+
+// inspired by https://github.com/testing-library/jest-dom?tab=readme-ov-file#tobevisible
+function isHiddenElement(element: SnapshotTargetElement): boolean {
+  if (element.hasAttribute("hidden")) {
+    return true;
+  }
+
+  const ariaHidden = booleanAttribute(element.ariaHidden);
+  if (ariaHidden === true) {
+    return true;
+  }
+
+  const cssStyles = window.getComputedStyle(element);
+  if (
+    cssStyles.display === "none" ||
+    cssStyles.visibility === "hidden" ||
+    cssStyles.visibility === "collapse" ||
+    cssStyles.opacity === "0"
+  ) {
+    return true;
+  }
+
+  return false;
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -105,6 +105,13 @@
                 "/url": "/live-regions"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Visually Hidden Elements'": {
+                "/url": "/visually-hidden-elements"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -123,6 +123,14 @@
                 "url": "/live-regions"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Visually Hidden Elements",
+                "url": "/visually-hidden-elements"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/visually_hidden_elements/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/visually_hidden_elements/ARIA_snapshot.json
@@ -1,0 +1,10 @@
+{
+  "main": [
+    "heading 'Hidden Elements' [level=1]",
+    "text 'hidden until-found element'",
+    "heading 'Elements Hidden by Inline Style' [level=2]",
+    "text 'opacity: 0 element'",
+    "heading 'Elements Hidden by Class Style' [level=2]",
+    "text 'opacity: 0 element'"
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/visually_hidden_elements/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/visually_hidden_elements/Element_snapshot.json
@@ -1,0 +1,22 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Hidden Elements",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Elements Hidden by Inline Style",
+        "level": 2
+      }
+    },
+    {
+      "heading": {
+        "name": "Elements Hidden by Class Style",
+        "level": 2
+      }
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -26,6 +26,9 @@
         <li><a href="/tables">Tables</a></li>
         <li><a href="/accessibility-tree">Accessibility Tree</a></li>
         <li><a href="/live-regions">Live Regions</a></li>
+        <li>
+          <a href="/visually-hidden-elements">Visually Hidden Elements</a>
+        </li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/test-pages/visually-hidden-elements.html
+++ b/packages/playwright-file-snapshots/test-pages/visually-hidden-elements.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hidden Elements</title>
+    <style>
+      .display-none {
+        display: none;
+      }
+
+      .visibility-hidden {
+        visibility: hidden;
+      }
+
+      .visibility-collapse {
+        visibility: collapse;
+      }
+
+      .opacity-0 {
+        opacity: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Hidden Elements</h1>
+      <div hidden>hidden element</div>
+      <div hidden="hidden">hidden hidden element</div>
+      <div hidden="hidden-with-custom-value">
+        hidden with custom value element
+      </div>
+      <div hidden="until-found">hidden until-found element</div>
+      <section>
+        <h2>Elements Hidden by Inline Style</h2>
+        <div style="display: none">display: none element</div>
+        <div style="visibility: hidden">visibility: hidden element</div>
+        <div style="visibility: collapse">visibility: collapse element</div>
+        <div style="opacity: 0">opacity: 0 element</div>
+      </section>
+      <section>
+        <h2>Elements Hidden by Class Style</h2>
+        <div class="display-none">display: none element</div>
+        <div class="visibility-hidden">visibility: hidden element</div>
+        <div class="visibility-collapse">visibility: collapse element</div>
+        <div class="opacity-0">opacity: 0 element</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -118,3 +118,8 @@ test("live regions", async ({ page }) => {
   await page.goto("/live-regions");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("visually hidden elements", async ({ page }) => {
+  await page.goto("/visually-hidden-elements");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR filters visually hidden elements from element snapshots, because they are no visible to a user.

The rules for detecting visually hidden elements are inspired by the [`toBeVisible` assertion from the Testing Library](https://github.com/testing-library/jest-dom?tab=readme-ov-file#tobevisible).

The following exceptions were not (yet) implemented due to low relevance:

- Elements with `hidden` attribute but `display: block` style (hidden in snapshots)
- `<details />` without `open` attribute (visible in snapshots)
