### PR TITLE
feat(playwright): Add element snapshot for roles `tablist`, `tab` and `tabpanel`

### DIFF
--- a/.changeset/two-emus-drive.md
+++ b/.changeset/two-emus-drive.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Add element snapshot for roles `tablist`, `tab` and `tabpanel`

--- a/packages/element-snapshot/src/snapshots/button.ts
+++ b/packages/element-snapshot/src/snapshots/button.ts
@@ -1,13 +1,14 @@
 import { booleanAttribute } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
+import type { DisableableAttributes } from "./state";
+import { disableableAttributes } from "./state";
 import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
 
 export interface ButtonSnapshot
   extends GenericElementSnapshot<"button", ButtonAttributes> {}
 
-interface ButtonAttributes {
-  disabled?: boolean;
+interface ButtonAttributes extends DisableableAttributes {
   expanded?: boolean;
 }
 
@@ -18,7 +19,7 @@ export function snapshotButton(
     role: "button",
     name: resolveAccessibleName(element),
     attributes: {
-      disabled: booleanAttribute(element.hasAttribute("disabled")),
+      ...disableableAttributes(element),
       expanded: booleanAttribute(element.ariaExpanded),
     },
     children: snapshotChildren(element),

--- a/packages/element-snapshot/src/snapshots/container.ts
+++ b/packages/element-snapshot/src/snapshots/container.ts
@@ -29,6 +29,8 @@ const CONTAINER_ROLES = [
   "alert",
   "menu",
   "menuitem",
+  "tablist",
+  "tabpanel",
 ] as const;
 
 export interface ContainerSnapshot

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -9,6 +9,7 @@ import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
 import { parseElementRole } from "./role";
+import { snapshotTab } from "./tab";
 import { snapshotTextNode } from "./text";
 import type {
   ElementRole,
@@ -39,6 +40,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   textbox: snapshotInput,
   dialog: snapshotDialogWithRole("dialog"),
   alertdialog: snapshotDialogWithRole("alertdialog"),
+  tab: snapshotTab,
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/snapshots/input.ts
+++ b/packages/element-snapshot/src/snapshots/input.ts
@@ -2,6 +2,8 @@ import { booleanAttribute, stringAttribute } from "./attribute";
 import { resolveDescription } from "./description";
 import { resolveAccessibleName } from "./name";
 import { resolveInputRole } from "./role";
+import type { DisableableAttributes } from "./state";
+import { disableableAttributes } from "./state";
 import { snapshotTextContent } from "./text";
 import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
 
@@ -23,11 +25,10 @@ interface InputAttributes extends CommonInputAttributes {
   checked?: boolean;
 }
 
-export interface CommonInputAttributes {
+export interface CommonInputAttributes extends DisableableAttributes {
   description?: string;
   placeholder?: string;
   readonly?: boolean;
-  disabled?: boolean;
   required?: boolean;
   invalid?: boolean;
 }
@@ -91,7 +92,7 @@ export function snapshotCommonInputAttributes(
     description: resolveDescription(element),
     placeholder: isEmpty ? resolvePlaceholder(element) : undefined,
     readonly: booleanAttribute(element.hasAttribute("readonly")),
-    disabled: booleanAttribute(element.disabled),
+    ...disableableAttributes(element),
     required: booleanAttribute(element.required),
     invalid: booleanAttribute(element.ariaInvalid),
   };

--- a/packages/element-snapshot/src/snapshots/role.ts
+++ b/packages/element-snapshot/src/snapshots/role.ts
@@ -68,6 +68,7 @@ const CONTEXT_DEPENDENT_ROLES: Partial<
   rowheader: isWithinTableRowOrGridRow,
   cell: isWithinTableRow,
   gridcell: isWithinGridRow,
+  tab: isWithinTablist,
 };
 
 const INPUT_ROLES: Record<string, ElementRoleResolver<InputRole | "button">> = {
@@ -240,4 +241,8 @@ function isWithinList(element: SnapshotTargetElement): boolean {
 
 function isWithinMenu(element: SnapshotTargetElement): boolean {
   return isWithinElement(element, roleSelector("menu"));
+}
+
+function isWithinTablist(element: SnapshotTargetElement): boolean {
+  return isWithinElement(element, roleSelector("tablist"));
 }

--- a/packages/element-snapshot/src/snapshots/state.ts
+++ b/packages/element-snapshot/src/snapshots/state.ts
@@ -1,0 +1,24 @@
+import { booleanAttribute } from "./attribute";
+import type { SnapshotTargetElement } from "./types";
+
+export interface DisableableAttributes {
+  disabled?: boolean;
+}
+
+export function disableableAttributes(
+  element: SnapshotTargetElement,
+): DisableableAttributes {
+  return {
+    disabled: booleanAttribute(element.hasAttribute("disabled")),
+  };
+}
+
+export interface SelectableAttributes {
+  selected?: boolean;
+}
+
+export function selectableAttributes(
+  element: SnapshotTargetElement,
+): SelectableAttributes {
+  return { selected: booleanAttribute(element.ariaSelected) };
+}

--- a/packages/element-snapshot/src/snapshots/tab.ts
+++ b/packages/element-snapshot/src/snapshots/tab.ts
@@ -1,0 +1,24 @@
+import { snapshotChildren } from "./children";
+import { resolveAccessibleName } from "./name";
+import type { DisableableAttributes, SelectableAttributes } from "./state";
+import { disableableAttributes, selectableAttributes } from "./state";
+import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
+
+export interface TabSnapshot
+  extends GenericElementSnapshot<"tab", TabAttributes> {}
+
+interface TabAttributes extends DisableableAttributes, SelectableAttributes {}
+
+export function snapshotTab(
+  element: SnapshotTargetElement,
+): TabSnapshot | null {
+  return {
+    role: "tab",
+    name: resolveAccessibleName(element),
+    attributes: {
+      ...disableableAttributes(element),
+      ...selectableAttributes(element),
+    },
+    children: snapshotChildren(element),
+  };
+}

--- a/packages/element-snapshot/src/snapshots/types.ts
+++ b/packages/element-snapshot/src/snapshots/types.ts
@@ -5,6 +5,7 @@ import type { DialogRole, DialogSnapshot } from "./dialog";
 import type { HeadingSnapshot } from "./heading";
 import type { InputRole, InputSnapshot } from "./input";
 import type { LinkSnapshot } from "./link";
+import type { TabSnapshot } from "./tab";
 import type { TextSnapshot } from "./text";
 
 export type SnapshotTargetNode = SnapshotTargetElement | ChildNode;
@@ -20,6 +21,7 @@ export type ElementRole =
   | "link"
   | "button"
   | "option"
+  | "tab"
   | ContainerRole
   | InputRole
   | DialogRole;
@@ -34,7 +36,8 @@ export type ElementSnapshot =
   | InputSnapshot
   | ComboboxSnapshot
   | OptionSnapshot
-  | DialogSnapshot;
+  | DialogSnapshot
+  | TabSnapshot;
 
 export interface GenericElementSnapshot<
   TRole extends NodeRole = NodeRole,

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -112,6 +112,13 @@
                 "/url": "/visually-hidden-elements"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Tabs'": {
+                "/url": "/tabs"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -131,6 +131,14 @@
                 "url": "/visually-hidden-elements"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Tabs",
+                "url": "/tabs"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/tabs/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/tabs/ARIA_snapshot.json
@@ -1,0 +1,18 @@
+{
+  "main": [
+    "heading 'Tabs' [level=1]",
+    "heading 'Complete Tabs' [level=2]",
+    {
+      "tablist 'Tablist'": [
+        "tab 'Tab 1' [selected]",
+        "tab 'Tab 2'",
+        "tab 'Tab 3'"
+      ]
+    },
+    {
+      "tabpanel 'Tab 1'": "Tabpanel 1"
+    },
+    "heading 'Incomplete Tabs' [level=2]",
+    "tab 'tab outside tablist'"
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/tabs/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/tabs/Element_snapshot.json
@@ -1,0 +1,50 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Tabs",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Complete Tabs",
+        "level": 2
+      }
+    },
+    {
+      "tablist": {
+        "name": "Tablist",
+        "children": [
+          {
+            "tab": {
+              "name": "Tab 1",
+              "selected": true
+            }
+          },
+          {
+            "tab": "Tab 2"
+          },
+          {
+            "tab": "Tab 3"
+          }
+        ]
+      }
+    },
+    {
+      "tabpanel": {
+        "name": "Tab 1",
+        "children": [
+          "Tabpanel 1"
+        ]
+      }
+    },
+    {
+      "heading": {
+        "name": "Incomplete Tabs",
+        "level": 2
+      }
+    },
+    "tab outside tablist"
+  ]
+}

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -29,6 +29,7 @@
         <li>
           <a href="/visually-hidden-elements">Visually Hidden Elements</a>
         </li>
+        <li><a href="/tabs">Tabs</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/test-pages/tabs.html
+++ b/packages/playwright-file-snapshots/test-pages/tabs.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tabs</title>
+  </head>
+  <body>
+    <main>
+      <h1>Tabs</h1>
+      <section>
+        <h2>Complete Tabs</h2>
+        <div role="tablist" aria-label="Tablist">
+          <button
+            role="tab"
+            aria-selected="true"
+            aria-controls="panel-1"
+            id="tab-1"
+            tabindex="0"
+          >
+            Tab 1
+          </button>
+          <button
+            role="tab"
+            aria-selected="false"
+            aria-controls="panel-2"
+            id="tab-2"
+            tabindex="-1"
+          >
+            Tab 2
+          </button>
+          <button
+            role="tab"
+            aria-selected="false"
+            aria-controls="panel-3"
+            id="tab-3"
+            tabindex="-1"
+          >
+            Tab 3
+          </button>
+        </div>
+        <div id="panel-1" role="tabpanel" tabindex="0" aria-labelledby="tab-1">
+          Tabpanel 1
+        </div>
+        <div
+          id="panel-2"
+          role="tabpanel"
+          tabindex="0"
+          aria-labelledby="tab-2"
+          hidden
+        >
+          Tabpanel 2
+        </div>
+        <div
+          id="panel-3"
+          role="tabpanel"
+          tabindex="0"
+          aria-labelledby="tab-3"
+          hidden
+        >
+          Tabpanel 3
+        </div>
+      </section>
+      <section>
+        <h2>Incomplete Tabs</h2>
+        <button role="tab">tab outside tablist</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -123,3 +123,8 @@ test("visually hidden elements", async ({ page }) => {
   await page.goto("/visually-hidden-elements");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("tabs", async ({ page }) => {
+  await page.goto("/tabs");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snapshotting elements with the roles `tablist`, `tab` and `tabpanel`.

**Role specifications on MDN**

- [tablist Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)
- [tab Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role)
- [tabpanel Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tabpanel_role)