### PR TITLE
fix(playwright): Import yaml dynamically to prevent error when packag…

### DIFF
--- a/.changeset/stale-books-smell.md
+++ b/.changeset/stale-books-smell.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": patch
+---
+
+Fix: Import `yaml` dynamically to prevent error when package is installed without optional peer dependency

--- a/packages/playwright-file-snapshots/src/aria-snapshot/snapshot.ts
+++ b/packages/playwright-file-snapshots/src/aria-snapshot/snapshot.ts
@@ -1,5 +1,4 @@
 import type { Locator } from "@playwright/test";
-import { parse } from "yaml";
 
 import {
   type PlainObject,
@@ -34,8 +33,17 @@ class AriaSnapshot {
 
   public async snapshot(locator: Locator): Promise<unknown> {
     const yamlSnapshot = await locator.ariaSnapshot();
-    const jsonSnapshot: unknown = parse(yamlSnapshot);
+    const jsonSnapshot: unknown = await this.parseYaml(yamlSnapshot);
     return this.normalizeJsonRecursive(jsonSnapshot);
+  }
+
+  private async parseYaml(yamlString: string): Promise<unknown> {
+    try {
+      const { parse } = await import("yaml");
+      return parse(yamlString);
+    } catch {
+      throw new Error("Missing peer dependency 'yaml'");
+    }
   }
 
   private normalizeJsonRecursive(value: unknown): unknown {


### PR DESCRIPTION
This PR fixes an issue where `playwright-file-snapshots` could not be used without installing `yaml`, which is optional and only needed when using `snapshotAria`.

Previously, a static `import` was used to load `yaml`, which ended up in the bundled package, leading to an error when `yaml` is not available. Now, a dynamic `import` is used, which is lazily executed only when `snapshotAria` is actually called.