### PR TITLE
fix(lib): Read snapshot files contain OS-specific linebreaks, leading to unintended matching errors

### DIFF
--- a/.changeset/silver-items-lead.md
+++ b/.changeset/silver-items-lead.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Fix: Read snapshot files use OS-specific linebreaks, leading to unintended matching errors

--- a/packages/lib-file-snapshots/src/utils/file.ts
+++ b/packages/lib-file-snapshots/src/utils/file.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 const NEW_LINE_SEPARATOR = "\n";
@@ -16,7 +17,13 @@ export function normalizeFileName(testName: string): string {
 }
 
 export function readSnapshotFile(path: string): string {
-  return fs.readFileSync(path, { encoding: "utf8" });
+  const contents = fs.readFileSync(path, { encoding: "utf8" });
+
+  if (os.EOL === NEW_LINE_SEPARATOR) {
+    return contents;
+  }
+
+  return contents.replace(new RegExp(os.EOL, "g"), NEW_LINE_SEPARATOR);
 }
 
 export function writeSnapshotFile(file: string, data: string): void {


### PR DESCRIPTION
This PR fixes an issue where file snapshots did not match on Windows because they were using Windows linebreaks (`\r\n`) instead of POSIX linebreaks (`\n`).

This was caused by Node's read file functions returning the contents using OS-specific linebreaks. Normalizing the read contents fixes the issue.