### PR TITLE
feat(playwright): Disable snapshot retries when update "all" snapshot…

### DIFF
--- a/.changeset/tough-numbers-pay.md
+++ b/.changeset/tough-numbers-pay.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Disable snapshot retries when update "all" snapshots is configured

--- a/packages/playwright-file-snapshots/src/matchers/utils.test.ts
+++ b/packages/playwright-file-snapshots/src/matchers/utils.test.ts
@@ -62,11 +62,14 @@ describe("parseTestInfo", () => {
 });
 
 describe("parseUpdateSnapshots", () => {
-  test("when value is 'changed', returns true", () => {
-    expect(parseUpdateSnapshots("changed")).toBe(true);
-  });
+  test.each(["changed", "all"] as const)(
+    "when value is '%s', returns true",
+    (value) => {
+      expect(parseUpdateSnapshots(value)).toBe(true);
+    },
+  );
 
-  test.each(["none", "missing", "all"] as const)(
+  test.each(["none", "missing"] as const)(
     "when value is '%s', returns false",
     (value) => {
       expect(parseUpdateSnapshots(value)).toBe(false);

--- a/packages/playwright-file-snapshots/src/matchers/utils.ts
+++ b/packages/playwright-file-snapshots/src/matchers/utils.ts
@@ -23,7 +23,7 @@ export async function parseTestInfo(
 export function parseUpdateSnapshots(
   updateSnapshots: TestInfo["config"]["updateSnapshots"],
 ): boolean {
-  return updateSnapshots === "changed";
+  return updateSnapshots === "changed" || updateSnapshots === "all";
 }
 
 type RawTestStepInfo = Pick<TestStepInfo, "titlePath">;


### PR DESCRIPTION
…s is configured

The new UI elements make it possible to select update "all" snapshots. A user will expect the same behaviour (disabled snapshot retries) when selecting this as they do from selecting "changed".