### PR TITLE
fix(playwright): Typing for `toMatchTextFile` does not allow to pass promises or value functions

### DIFF
--- a/.changeset/twelve-banks-grow.md
+++ b/.changeset/twelve-banks-grow.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Fix: Typing for `toMatchTextFile` does not allow to pass promises or functions as value

--- a/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_async_function_value_with_JSON_file.json
+++ b/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_async_function_value_with_JSON_file.json
@@ -1,0 +1,3 @@
+[
+  "async function value"
+]

--- a/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_async_value_with_JSON_file.json
+++ b/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_async_value_with_JSON_file.json
@@ -1,0 +1,3 @@
+[
+  "async value"
+]

--- a/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_function_value_with_JSON_file.json
+++ b/packages/playwright-file-snapshots/data/test/validation/json-file-matcher/matches_function_value_with_JSON_file.json
@@ -1,0 +1,3 @@
+[
+  "function value"
+]

--- a/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_async_function_value_with_text_file.txt
+++ b/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_async_function_value_with_text_file.txt
@@ -1,0 +1,1 @@
+async function value

--- a/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_async_value_with_text_file.txt
+++ b/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_async_value_with_text_file.txt
@@ -1,0 +1,1 @@
+async value

--- a/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_function_value_with_text_file.txt
+++ b/packages/playwright-file-snapshots/data/test/validation/text-file-matcher/matches_function_value_with_text_file.txt
@@ -1,0 +1,1 @@
+function value

--- a/packages/playwright-file-snapshots/src/matchers/types.ts
+++ b/packages/playwright-file-snapshots/src/matchers/types.ts
@@ -38,13 +38,19 @@ export interface PlaywrightValidationFileMatcherConfig {
   resolveFilePath?: FilePathResolver;
 }
 
+type ValueOrValueFunction<TValue> =
+  | TValue
+  | Promise<TValue>
+  | (() => TValue)
+  | (() => Promise<TValue>);
+
 export interface PlaywrightValidationFileMatchers {
   toMatchJsonFile: (
-    actual: unknown,
+    actual: ValueOrValueFunction<unknown>,
     options?: PlaywrightMatchJsonFileOptions,
   ) => Promise<MatcherReturnType>;
   toMatchTextFile: (
-    actual: string,
+    actual: ValueOrValueFunction<string>,
     options?: PlaywrightMatchTextFileOptions,
   ) => Promise<MatcherReturnType>;
 }

--- a/packages/playwright-file-snapshots/tests/json-file-matcher.spec.ts
+++ b/packages/playwright-file-snapshots/tests/json-file-matcher.spec.ts
@@ -9,6 +9,20 @@ test("matches value with JSON file", async () => {
   await expect({ key: "value" }).toMatchJsonFile();
 });
 
+test("matches async value with JSON file", async () => {
+  await expect(Promise.resolve(["async value"])).toMatchJsonFile();
+});
+
+test("matches function value with JSON file", async () => {
+  await expect(() => ["function value"]).toMatchJsonFile();
+});
+
+test("matches async function value with JSON file", async () => {
+  await expect(() =>
+    Promise.resolve(["async function value"]),
+  ).toMatchJsonFile();
+});
+
 test("when includeUndefinedObjectProperties is true, serializes undefined object properties", async () => {
   await expect({ undefinedValue: undefined }).toMatchJsonFile({
     includeUndefinedObjectProperties: true,

--- a/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
+++ b/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
@@ -9,6 +9,18 @@ test("matches value with text file", async () => {
   await expect("value").toMatchTextFile();
 });
 
+test("matches async value with text file", async () => {
+  await expect(Promise.resolve("async value")).toMatchTextFile();
+});
+
+test("matches function value with text file", async () => {
+  await expect(() => "function value").toMatchTextFile();
+});
+
+test("matches async function value with text file", async () => {
+  await expect(() => Promise.resolve("async function value")).toMatchTextFile();
+});
+
 test("applies normalizer", async () => {
   function maskNumber(value: string): string {
     return value.replaceAll(/\d+/g, "[NUMBER]");


### PR DESCRIPTION
This PR fixes a bug where `toMatchTextFile` could only be called with string values based on it's type, even though Promises returning strings and functions returning either of both are supported. This prevented calling the matcher on non-string values, because it resulted in a type error.