### PR TITLE
chore(playwright): Expose types `NodeRole` and `ElementRole`

### DIFF
--- a/.changeset/nine-teeth-roll.md
+++ b/.changeset/nine-teeth-roll.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Expose types `NodeRole` and `ElementRole`

--- a/packages/element-snapshot/src/types.ts
+++ b/packages/element-snapshot/src/types.ts
@@ -1,2 +1,7 @@
-export type { NodeSnapshot, ElementSnapshot } from "./snapshots/types";
+export type {
+  ElementRole,
+  ElementSnapshot,
+  NodeRole,
+  NodeSnapshot,
+} from "./snapshots/types";
 export type { TextSnapshot } from "./snapshots/text";


### PR DESCRIPTION
This PR exposes the types `NodeRole` and `ElementRole` to facilitate developing custom snapshots based on `snapshotElementRaw`.