### PR TITLE
feat(playwright): Snapshot attributes `url` and `disabled` for elements with role `menuitem`

### DIFF
--- a/.changeset/sour-showers-bathe.md
+++ b/.changeset/sour-showers-bathe.md
@@ -1,0 +1,6 @@
+---
+"@cronn/playwright-file-snapshots": minor
+"@cronn/element-snapshot": minor
+---
+
+Snapshot attributes `url` and `disabled` for elements with role `menuitem`

--- a/packages/element-snapshot/src/snapshots/container.ts
+++ b/packages/element-snapshot/src/snapshots/container.ts
@@ -28,7 +28,6 @@ const CONTAINER_ROLES = [
   "gridcell",
   "alert",
   "menu",
-  "menuitem",
   "tablist",
   "tabpanel",
 ] as const;

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -8,6 +8,7 @@ import { snapshotDialogWithRole } from "./dialog";
 import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
+import { snapshotMenuitem } from "./list";
 import { parseElementRole } from "./role";
 import { snapshotTab } from "./tab";
 import { snapshotTextNode } from "./text";
@@ -41,6 +42,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   dialog: snapshotDialogWithRole("dialog"),
   alertdialog: snapshotDialogWithRole("alertdialog"),
   tab: snapshotTab,
+  menuitem: snapshotMenuitem,
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/snapshots/link.ts
+++ b/packages/element-snapshot/src/snapshots/link.ts
@@ -6,7 +6,7 @@ import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
 export interface LinkSnapshot
   extends GenericElementSnapshot<"link", LinkAttributes> {}
 
-interface LinkAttributes {
+export interface LinkAttributes {
   url?: string;
 }
 
@@ -14,7 +14,11 @@ export function snapshotLink(element: SnapshotTargetElement): LinkSnapshot {
   return {
     role: "link",
     name: resolveAccessibleName(element),
-    attributes: { url: stringAttribute(element.getAttribute("href")) },
+    attributes: linkAttributes(element),
     children: snapshotChildren(element),
   };
+}
+
+export function linkAttributes(element: SnapshotTargetElement): LinkAttributes {
+  return { url: stringAttribute(element.getAttribute("href")) };
 }

--- a/packages/element-snapshot/src/snapshots/list.ts
+++ b/packages/element-snapshot/src/snapshots/list.ts
@@ -1,0 +1,26 @@
+import { snapshotChildren } from "./children";
+import type { LinkAttributes } from "./link";
+import { linkAttributes } from "./link";
+import { resolveAccessibleName } from "./name";
+import type { DisableableAttributes } from "./state";
+import { disableableAttributes } from "./state";
+import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
+
+export interface MenuitemSnapshot
+  extends GenericElementSnapshot<"menuitem", MenuitemAttributes> {}
+
+interface MenuitemAttributes extends LinkAttributes, DisableableAttributes {}
+
+export function snapshotMenuitem(
+  element: SnapshotTargetElement,
+): MenuitemSnapshot {
+  return {
+    role: "menuitem",
+    name: resolveAccessibleName(element),
+    attributes: {
+      ...linkAttributes(element),
+      ...disableableAttributes(element, true),
+    },
+    children: snapshotChildren(element),
+  };
+}

--- a/packages/element-snapshot/src/snapshots/state.ts
+++ b/packages/element-snapshot/src/snapshots/state.ts
@@ -7,9 +7,16 @@ export interface DisableableAttributes {
 
 export function disableableAttributes(
   element: SnapshotTargetElement,
+  ariaOnly = false,
 ): DisableableAttributes {
+  if (ariaOnly) {
+    return { disabled: booleanAttribute(element.ariaDisabled) };
+  }
+
   return {
-    disabled: booleanAttribute(element.hasAttribute("disabled")),
+    disabled:
+      booleanAttribute(element.hasAttribute("disabled")) ??
+      booleanAttribute(element.ariaDisabled),
   };
 }
 

--- a/packages/element-snapshot/src/snapshots/types.ts
+++ b/packages/element-snapshot/src/snapshots/types.ts
@@ -5,6 +5,7 @@ import type { DialogRole, DialogSnapshot } from "./dialog";
 import type { HeadingSnapshot } from "./heading";
 import type { InputRole, InputSnapshot } from "./input";
 import type { LinkSnapshot } from "./link";
+import type { MenuitemSnapshot } from "./list";
 import type { TabSnapshot } from "./tab";
 import type { TextSnapshot } from "./text";
 
@@ -22,6 +23,7 @@ export type ElementRole =
   | "button"
   | "option"
   | "tab"
+  | "menuitem"
   | ContainerRole
   | InputRole
   | DialogRole;
@@ -37,7 +39,8 @@ export type ElementSnapshot =
   | ComboboxSnapshot
   | OptionSnapshot
   | DialogSnapshot
-  | TabSnapshot;
+  | TabSnapshot
+  | MenuitemSnapshot;
 
 export interface GenericElementSnapshot<
   TRole extends NodeRole = NodeRole,

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/ARIA_snapshot.json
@@ -61,7 +61,8 @@
     {
       "menu 'Menu'": [
         "menuitem 'Menu Item 1'",
-        "menuitem 'Menu Item 2'"
+        "menuitem 'Disabled Menu Item' [disabled]",
+        "menuitem 'Link Menu Item'"
       ]
     },
     "heading 'Incomplete List' [level=2]",

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/lists/Element_snapshot.json
@@ -108,7 +108,16 @@
             "menuitem": "Menu Item 1"
           },
           {
-            "menuitem": "Menu Item 2"
+            "menuitem": {
+              "name": "Disabled Menu Item",
+              "disabled": true
+            }
+          },
+          {
+            "menuitem": {
+              "name": "Link Menu Item",
+              "url": "/"
+            }
           }
         ]
       }

--- a/packages/playwright-file-snapshots/test-pages/lists.html
+++ b/packages/playwright-file-snapshots/test-pages/lists.html
@@ -58,7 +58,8 @@
         </button>
         <ul id="menu" role="menu" aria-labelledby="menubutton">
           <li role="menuitem">Menu Item 1</li>
-          <li role="menuitem">Menu Item 2</li>
+          <li role="menuitem" aria-disabled="true">Disabled Menu Item</li>
+          <li role="menuitem" href="/">Link Menu Item</li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
This PR adds support for snapshotting the `href` and `aria-disabled` attributes on elements with role `menuitem`.