### PR TITLE
chore(playwright): Expose all element snapshot types

### DIFF
--- a/packages/element-snapshot/src/types.ts
+++ b/packages/element-snapshot/src/types.ts
@@ -5,3 +5,14 @@ export type {
   NodeSnapshot,
 } from "./snapshots/types";
 export type { TextSnapshot } from "./snapshots/text";
+
+export type { ButtonSnapshot } from "./snapshots/button";
+export type { ComboboxSnapshot, OptionSnapshot } from "./snapshots/combobox";
+export type { ContainerSnapshot } from "./snapshots/container";
+export type { DialogSnapshot } from "./snapshots/dialog";
+export type { HeadingSnapshot } from "./snapshots/heading";
+export type { InputSnapshot } from "./snapshots/input";
+export type { LinkSnapshot } from "./snapshots/link";
+export type { MenuitemSnapshot } from "./snapshots/list";
+export type { TabSnapshot } from "./snapshots/tab";
+export type { ColumnheaderSnapshot } from "./snapshots/table";

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -11,8 +11,21 @@ export type {
 } from "./matchers/types";
 
 export type {
-  NodeSnapshot,
+  ButtonSnapshot,
+  ColumnheaderSnapshot,
+  ComboboxSnapshot,
+  ContainerSnapshot,
+  DialogSnapshot,
+  ElementRole,
   ElementSnapshot,
+  HeadingSnapshot,
+  InputSnapshot,
+  LinkSnapshot,
+  MenuitemSnapshot,
+  NodeRole,
+  NodeSnapshot,
+  OptionSnapshot,
+  TabSnapshot,
   TextSnapshot,
 } from "@cronn/element-snapshot/types";
 


### PR DESCRIPTION
This PR exposes all relevant element snapshot types for writing custom snapshot transformers.