### PR TITLE
feat(playwright): Snapshot elements with role `group`

### DIFF
--- a/.changeset/slow-pandas-poke.md
+++ b/.changeset/slow-pandas-poke.md
@@ -1,0 +1,6 @@
+---
+"@cronn/playwright-file-snapshots": minor
+"@cronn/element-snapshot": minor
+---
+
+Snapshot elements with role `group`

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -5,6 +5,7 @@ import { snapshotCombobox, snapshotOption } from "./combobox";
 import type { ContainerRole } from "./container";
 import { snapshotContainer } from "./container";
 import { snapshotDialogWithRole } from "./dialog";
+import { snapshotGroup } from "./group";
 import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
@@ -45,6 +46,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   tab: snapshotTab,
   menuitem: snapshotMenuitem,
   columnheader: snapshotColumnheader,
+  group: snapshotGroup,
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/snapshots/group.ts
+++ b/packages/element-snapshot/src/snapshots/group.ts
@@ -1,0 +1,28 @@
+import { snapshotChildren } from "./children";
+import { resolveAccessibleName } from "./name";
+import { snapshotTextContent } from "./text";
+import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
+
+export interface GroupSnapshot extends GenericElementSnapshot<"group"> {}
+
+export function snapshotGroup(
+  element: SnapshotTargetElement,
+): GroupSnapshot | null {
+  return {
+    role: "group",
+    name: resolveGroupName(element),
+    children: snapshotChildren(element),
+  };
+}
+
+function resolveGroupName(element: SnapshotTargetElement): string | undefined {
+  const legendElement =
+    element instanceof HTMLFieldSetElement
+      ? element.querySelector("legend")
+      : null;
+  if (legendElement !== null) {
+    return snapshotTextContent(legendElement);
+  }
+
+  return resolveAccessibleName(element, false);
+}

--- a/packages/element-snapshot/src/snapshots/role.ts
+++ b/packages/element-snapshot/src/snapshots/role.ts
@@ -51,6 +51,7 @@ const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   tr: "row",
   th: resolveTableHeaderCellRole,
   td: "cell",
+  fieldset: "group",
 };
 
 const CONTEXT_DEPENDENT_ROLES: Partial<

--- a/packages/element-snapshot/src/snapshots/types.ts
+++ b/packages/element-snapshot/src/snapshots/types.ts
@@ -2,6 +2,7 @@ import type { ButtonSnapshot } from "./button";
 import type { ComboboxSnapshot, OptionSnapshot } from "./combobox";
 import type { ContainerRole, ContainerSnapshot } from "./container";
 import type { DialogRole, DialogSnapshot } from "./dialog";
+import type { GroupSnapshot } from "./group";
 import type { HeadingSnapshot } from "./heading";
 import type { InputRole, InputSnapshot } from "./input";
 import type { LinkSnapshot } from "./link";
@@ -26,6 +27,7 @@ export type ElementRole =
   | "tab"
   | "menuitem"
   | "columnheader"
+  | "group"
   | ContainerRole
   | InputRole
   | DialogRole;
@@ -43,7 +45,8 @@ export type ElementSnapshot =
   | DialogSnapshot
   | TabSnapshot
   | MenuitemSnapshot
-  | ColumnheaderSnapshot;
+  | ColumnheaderSnapshot
+  | GroupSnapshot;
 
 export interface GenericElementSnapshot<
   TRole extends NodeRole = NodeRole,

--- a/packages/element-snapshot/src/types.ts
+++ b/packages/element-snapshot/src/types.ts
@@ -10,6 +10,7 @@ export type { ButtonSnapshot } from "./snapshots/button";
 export type { ComboboxSnapshot, OptionSnapshot } from "./snapshots/combobox";
 export type { ContainerSnapshot } from "./snapshots/container";
 export type { DialogSnapshot } from "./snapshots/dialog";
+export type { GroupSnapshot } from "./snapshots/group";
 export type { HeadingSnapshot } from "./snapshots/heading";
 export type { InputSnapshot } from "./snapshots/input";
 export type { LinkSnapshot } from "./snapshots/link";

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/groups/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/groups/ARIA_snapshot.json
@@ -1,0 +1,28 @@
+{
+  "main": [
+    "heading 'Groups' [level=1]",
+    "heading 'Fieldset' [level=2]",
+    {
+      "group 'Fieldset Name'": [
+        "text 'Fieldset Name First Name'",
+        "textbox 'First Name'",
+        "text 'Last Name'",
+        "textbox 'Last Name'"
+      ]
+    },
+    "heading 'Role-Based Group' [level=2]",
+    {
+      "menu": [
+        {
+          "group": [
+            "menuitem 'Menu Item 1'",
+            "menuitem 'Menu Item 2'"
+          ]
+        },
+        {
+          "group 'Named Group'": "menuitem 'Menu Item 3'"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/groups/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/groups/Element_snapshot.json
@@ -1,0 +1,62 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Groups",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Fieldset",
+        "level": 2
+      }
+    },
+    {
+      "group": {
+        "name": "Fieldset Name",
+        "children": [
+          "Fieldset Name",
+          "First Name",
+          {
+            "textbox": "First Name"
+          },
+          "Last Name",
+          {
+            "textbox": "Last Name"
+          }
+        ]
+      }
+    },
+    {
+      "heading": {
+        "name": "Role-Based Group",
+        "level": 2
+      }
+    },
+    {
+      "menu": [
+        {
+          "group": [
+            {
+              "menuitem": "Menu Item 1"
+            },
+            {
+              "menuitem": "Menu Item 2"
+            }
+          ]
+        },
+        {
+          "group": {
+            "name": "Named Group",
+            "children": [
+              {
+                "menuitem": "Menu Item 3"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -126,6 +126,13 @@
                 "/url": "/buttons"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Groups'": {
+                "/url": "/groups"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -147,6 +147,14 @@
                 "url": "/buttons"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Groups",
+                "url": "/groups"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -18,6 +18,7 @@ export type {
   DialogSnapshot,
   ElementRole,
   ElementSnapshot,
+  GroupSnapshot,
   HeadingSnapshot,
   InputSnapshot,
   LinkSnapshot,

--- a/packages/playwright-file-snapshots/test-pages/groups.html
+++ b/packages/playwright-file-snapshots/test-pages/groups.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Groups</title>
+  </head>
+  <body>
+    <main>
+      <h1>Groups</h1>
+      <section>
+        <h2>Fieldset</h2>
+        <fieldset>
+          <legend>Fieldset Name</legend>
+          <label for="firstName">First Name</label>
+          <input type="text" name="firstName" id="firstName" />
+          <label for="lastName">Last Name</label>
+          <input type="text" name="lastName" id="lastName" />
+        </fieldset>
+      </section>
+      <section>
+        <h2>Role-Based Group</h2>
+        <div role="menu">
+          <ul role="group">
+            <li role="menuitem">Menu Item 1</li>
+            <li role="menuitem">Menu Item 2</li>
+          </ul>
+          <ul role="group" aria-label="Named Group">
+            <li role="menuitem">Menu Item 3</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -31,6 +31,7 @@
         </li>
         <li><a href="/tabs">Tabs</a></li>
         <li><a href="/buttons">Buttons</a></li>
+        <li><a href="/groups">Groups</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -133,3 +133,8 @@ test("buttons", async ({ page }) => {
   await page.goto("/buttons");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("groups", async ({ page }) => {
+  await page.goto("/groups");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snapshotting elements with the role `group`, including `<fieldset>` elements and arbitrary elements with an explicit `role` attribute.