### PR TITLE
feat(playwright): Add `pressed` attribute to element snapshot for role `button`

### DIFF
--- a/.changeset/smart-ghosts-act.md
+++ b/.changeset/smart-ghosts-act.md
@@ -1,0 +1,6 @@
+---
+"@cronn/playwright-file-snapshots": minor
+"@cronn/element-snapshot": minor
+---
+
+Add `pressed` attribute to element snapshot for role `button`

--- a/packages/element-snapshot/src/snapshots/button.ts
+++ b/packages/element-snapshot/src/snapshots/button.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute } from "./attribute";
+import { booleanAttribute, enumAttribute } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
 import type { DisableableAttributes } from "./state";
@@ -10,7 +10,12 @@ export interface ButtonSnapshot
 
 interface ButtonAttributes extends DisableableAttributes {
   expanded?: boolean;
+  pressed?: PressedValue;
 }
+
+type PressedValue = true | "mixed";
+
+const PRESSED_VALUES = new Set(["true", "mixed", "false"] as const);
 
 export function snapshotButton(
   element: SnapshotTargetElement,
@@ -21,7 +26,19 @@ export function snapshotButton(
     attributes: {
       ...disableableAttributes(element),
       expanded: booleanAttribute(element.ariaExpanded),
+      pressed: resolvePressedAttribute(element),
     },
     children: snapshotChildren(element),
   };
+}
+
+function resolvePressedAttribute(
+  element: SnapshotTargetElement,
+): PressedValue | undefined {
+  const pressed = enumAttribute(element.ariaPressed, PRESSED_VALUES);
+  if (pressed === "mixed") {
+    return pressed;
+  }
+
+  return booleanAttribute(pressed === "true");
 }

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/buttons/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/buttons/ARIA_snapshot.json
@@ -1,0 +1,9 @@
+{
+  "main": [
+    "heading 'Buttons' [level=1]",
+    "heading 'Toggle Buttons' [level=2]",
+    "button '[aria-pressed=true]' [pressed]",
+    "button '[aria-pressed=mixed]' [pressed=mixed]",
+    "button '[aria-pressed=false]'"
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/buttons/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/buttons/Element_snapshot.json
@@ -1,0 +1,31 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Buttons",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Toggle Buttons",
+        "level": 2
+      }
+    },
+    {
+      "button": {
+        "name": "[aria-pressed=true]",
+        "pressed": true
+      }
+    },
+    {
+      "button": {
+        "name": "[aria-pressed=mixed]",
+        "pressed": "mixed"
+      }
+    },
+    {
+      "button": "[aria-pressed=false]"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -119,6 +119,13 @@
                 "/url": "/tabs"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Buttons'": {
+                "/url": "/buttons"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -139,6 +139,14 @@
                 "url": "/tabs"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Buttons",
+                "url": "/buttons"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/test-pages/buttons.html
+++ b/packages/playwright-file-snapshots/test-pages/buttons.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Buttons</title>
+  </head>
+  <body>
+    <main>
+      <h1>Buttons</h1>
+      <section>
+        <h2>Toggle Buttons</h2>
+        <button aria-pressed="true">[aria-pressed=true]</button>
+        <button aria-pressed="mixed">[aria-pressed=mixed]</button>
+        <button aria-pressed="false">[aria-pressed=false]</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -30,6 +30,7 @@
           <a href="/visually-hidden-elements">Visually Hidden Elements</a>
         </li>
         <li><a href="/tabs">Tabs</a></li>
+        <li><a href="/buttons">Buttons</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -128,3 +128,8 @@ test("tabs", async ({ page }) => {
   await page.goto("/tabs");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("buttons", async ({ page }) => {
+  await page.goto("/buttons");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snapshotting toggle buttons. It adds the `pressed` attribute to element snapshots for the role `button`.