### PR TITLE
feat(playwright): Snapshot elements with role `progressbar`

### DIFF
--- a/.changeset/cuddly-ties-make.md
+++ b/.changeset/cuddly-ties-make.md
@@ -1,0 +1,6 @@
+---
+"@cronn/playwright-file-snapshots": minor
+"@cronn/element-snapshot": minor
+---
+
+Snapshot elements with role `progressbar`

--- a/packages/element-snapshot/src/snapshots/element.ts
+++ b/packages/element-snapshot/src/snapshots/element.ts
@@ -10,6 +10,7 @@ import { snapshotHeading } from "./heading";
 import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
 import { snapshotMenuitem } from "./list";
+import { snapshotProgressbar } from "./progressbar";
 import { parseElementRole } from "./role";
 import { snapshotTab } from "./tab";
 import { snapshotColumnheader } from "./table";
@@ -47,6 +48,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   menuitem: snapshotMenuitem,
   columnheader: snapshotColumnheader,
   group: snapshotGroup,
+  progressbar: snapshotProgressbar,
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/snapshots/progressbar.ts
+++ b/packages/element-snapshot/src/snapshots/progressbar.ts
@@ -1,0 +1,32 @@
+import { numericAttribute } from "./attribute";
+import { snapshotChildren } from "./children";
+import { resolveAccessibleName } from "./name";
+import type { GenericElementSnapshot, SnapshotTargetElement } from "./types";
+
+export interface ProgressbarSnapshot
+  extends GenericElementSnapshot<"progressbar", ProgressbarAttributes> {}
+
+interface ProgressbarAttributes {
+  value?: number;
+}
+
+export function snapshotProgressbar(
+  element: SnapshotTargetElement,
+): ProgressbarSnapshot {
+  return {
+    role: "progressbar",
+    name: resolveAccessibleName(element, false),
+    attributes: {
+      value: resolveValue(element),
+    },
+    children: snapshotChildren(element),
+  };
+}
+
+function resolveValue(element: SnapshotTargetElement): number | undefined {
+  if (element instanceof HTMLProgressElement) {
+    return element.value;
+  }
+
+  return numericAttribute(element.ariaValueNow);
+}

--- a/packages/element-snapshot/src/snapshots/role.ts
+++ b/packages/element-snapshot/src/snapshots/role.ts
@@ -52,6 +52,7 @@ const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   th: resolveTableHeaderCellRole,
   td: "cell",
   fieldset: "group",
+  progress: "progressbar",
 };
 
 const CONTEXT_DEPENDENT_ROLES: Partial<

--- a/packages/element-snapshot/src/snapshots/types.ts
+++ b/packages/element-snapshot/src/snapshots/types.ts
@@ -7,6 +7,7 @@ import type { HeadingSnapshot } from "./heading";
 import type { InputRole, InputSnapshot } from "./input";
 import type { LinkSnapshot } from "./link";
 import type { MenuitemSnapshot } from "./list";
+import type { ProgressbarSnapshot } from "./progressbar";
 import type { TabSnapshot } from "./tab";
 import type { ColumnheaderSnapshot } from "./table";
 import type { TextSnapshot } from "./text";
@@ -28,6 +29,7 @@ export type ElementRole =
   | "menuitem"
   | "columnheader"
   | "group"
+  | "progressbar"
   | ContainerRole
   | InputRole
   | DialogRole;
@@ -46,7 +48,8 @@ export type ElementSnapshot =
   | TabSnapshot
   | MenuitemSnapshot
   | ColumnheaderSnapshot
-  | GroupSnapshot;
+  | GroupSnapshot
+  | ProgressbarSnapshot;
 
 export interface GenericElementSnapshot<
   TRole extends NodeRole = NodeRole,

--- a/packages/element-snapshot/src/types.ts
+++ b/packages/element-snapshot/src/types.ts
@@ -15,5 +15,6 @@ export type { HeadingSnapshot } from "./snapshots/heading";
 export type { InputSnapshot } from "./snapshots/input";
 export type { LinkSnapshot } from "./snapshots/link";
 export type { MenuitemSnapshot } from "./snapshots/list";
+export type { ProgressbarSnapshot } from "./snapshots/progressbar";
 export type { TabSnapshot } from "./snapshots/tab";
 export type { ColumnheaderSnapshot } from "./snapshots/table";

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -133,6 +133,13 @@
                 "/url": "/groups"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Progressbars'": {
+                "/url": "/progressbars"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -155,6 +155,14 @@
                 "url": "/groups"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Progressbars",
+                "url": "/progressbars"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/progressbars/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/progressbars/ARIA_snapshot.json
@@ -1,0 +1,13 @@
+{
+  "main": [
+    "heading 'Progressbars' [level=1]",
+    "heading 'Progress Element' [level=2]",
+    {
+      "progressbar": "70%"
+    },
+    "heading 'Role-Based Progressbar' [level=2]",
+    {
+      "progressbar 'Loading…'": "70%"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/progressbars/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/progressbars/Element_snapshot.json
@@ -1,0 +1,39 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Progressbars",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "Progress Element",
+        "level": 2
+      }
+    },
+    {
+      "progressbar": {
+        "value": 70,
+        "children": [
+          "70%"
+        ]
+      }
+    },
+    {
+      "heading": {
+        "name": "Role-Based Progressbar",
+        "level": 2
+      }
+    },
+    {
+      "progressbar": {
+        "name": "Loading…",
+        "value": 70,
+        "children": [
+          "70%"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -26,6 +26,7 @@ export type {
   NodeRole,
   NodeSnapshot,
   OptionSnapshot,
+  ProgressbarSnapshot,
   TabSnapshot,
   TextSnapshot,
 } from "@cronn/element-snapshot/types";

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -32,6 +32,7 @@
         <li><a href="/tabs">Tabs</a></li>
         <li><a href="/buttons">Buttons</a></li>
         <li><a href="/groups">Groups</a></li>
+        <li><a href="/progressbars">Progressbars</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/test-pages/progressbars.html
+++ b/packages/playwright-file-snapshots/test-pages/progressbars.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Progressbars</title>
+  </head>
+  <body>
+    <main>
+      <h1>Progressbars</h1>
+      <section>
+        <h2>Progress Element</h2>
+        <progress value="70" max="100">70%</progress>
+      </section>
+      <section>
+        <h2>Role-Based Progressbar</h2>
+        <span
+          role="progressbar"
+          aria-label="Loading…"
+          aria-valuenow="70"
+          aria-valuemax="100"
+          >70%</span
+        >
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -138,3 +138,8 @@ test("groups", async ({ page }) => {
   await page.goto("/groups");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("progressbars", async ({ page }) => {
+  await page.goto("/progressbars");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snaphotting elements with the role `progressbar`.

Further reading

- [progress Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress)
- [progressbar role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role)