### PR TITLE
ci: Block exotic subdeps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,8 +36,8 @@ strictDepBuilds: true
 ignoredBuiltDependencies:
   - esbuild
 
-minimumReleaseAge: 10080
+minimumReleaseAge: 10080 # 1 week
 
 trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 10080
+trustPolicyIgnoreAfter: 40320 # 4 weeks
 blockExoticSubdeps: true


### PR DESCRIPTION
This PR enables `blockExoticSubdeps` to increase the protection against supply chain attacks.

In addition, it increases `trustPolicyIgnoreAfter` to make `trustPolicy` effective again.