### PR TITLE
feat(playwright): Snapshot `separator` elements

### DIFF
--- a/.changeset/dry-teeth-teach.md
+++ b/.changeset/dry-teeth-teach.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Snapshot `hr` elements and elements with role `separator`

--- a/packages/element-snapshot/src/browser/container.ts
+++ b/packages/element-snapshot/src/browser/container.ts
@@ -33,6 +33,7 @@ const CONTAINER_ROLES = new Set([
   "menu",
   "tablist",
   "tabpanel",
+  "separator",
 ] as const);
 
 export interface ContainerSnapshot extends GenericElementSnapshot<ContainerRole> {}

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -53,6 +53,7 @@ const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   td: "cell",
   fieldset: "group",
   progress: "progressbar",
+  hr: "separator",
 };
 
 const CONTEXT_DEPENDENT_ROLES: Partial<

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/ARIA_snapshot.json
@@ -140,6 +140,13 @@
                 "/url": "/progressbars"
               }
             }
+          },
+          {
+            "listitem": {
+              "link 'Separators'": {
+                "/url": "/separators"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/page/Element_snapshot.json
@@ -163,6 +163,14 @@
                 "url": "/progressbars"
               }
             }
+          },
+          {
+            "listitem": {
+              "link": {
+                "name": "Separators",
+                "url": "/separators"
+              }
+            }
           }
         ]
       },

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/separators/ARIA_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/separators/ARIA_snapshot.json
@@ -1,0 +1,12 @@
+{
+  "main": [
+    "heading 'Separators' [level=1]",
+    "heading 'HR Element' [level=2]",
+    "separator",
+    "heading 'Role-Based Separators' [level=2]",
+    "separator",
+    {
+      "separator": "Separator with text content"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/separators/Element_snapshot.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/separators/Element_snapshot.json
@@ -1,0 +1,31 @@
+{
+  "main": [
+    {
+      "heading": {
+        "name": "Separators",
+        "level": 1
+      }
+    },
+    {
+      "heading": {
+        "name": "HR Element",
+        "level": 2
+      }
+    },
+    {
+      "separator": ""
+    },
+    {
+      "heading": {
+        "name": "Role-Based Separators",
+        "level": 2
+      }
+    },
+    {
+      "separator": ""
+    },
+    {
+      "separator": "Separator with text content"
+    }
+  ]
+}

--- a/packages/playwright-file-snapshots/test-pages/index.html
+++ b/packages/playwright-file-snapshots/test-pages/index.html
@@ -33,6 +33,7 @@
         <li><a href="/buttons">Buttons</a></li>
         <li><a href="/groups">Groups</a></li>
         <li><a href="/progressbars">Progressbars</a></li>
+        <li><a href="/separators">Separators</a></li>
       </ul>
       <search>
         <form>

--- a/packages/playwright-file-snapshots/test-pages/separators.html
+++ b/packages/playwright-file-snapshots/test-pages/separators.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Separators</title>
+  </head>
+  <body>
+    <main>
+      <h1>Separators</h1>
+      <section>
+        <h2>HR Element</h2>
+        <hr />
+      </section>
+      <section>
+        <h2>Role-Based Separators</h2>
+        <span role="separator"></span>
+        <span role="separator">Separator with text content</span>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -151,3 +151,8 @@ test("filter elements", async ({ page }) => {
     }),
   ).toMatchJsonFile({ name: "headings" });
 });
+
+test("separators", async ({ page }) => {
+  await page.goto("/separators");
+  await testSnapshots(page.getByRole("main"));
+});


### PR DESCRIPTION
This PR adds support for snapshotting separator elements, including `hr` elements and elements with `role="separator"`.