### PR TITLE
feat(playwright): Add filter option to element snapshot

### DIFF
--- a/.changeset/modern-pillows-slide.md
+++ b/.changeset/modern-pillows-slide.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add option `filter` to selectively include elements in the snapshot

--- a/packages/element-snapshot/README.md
+++ b/packages/element-snapshot/README.md
@@ -82,12 +82,17 @@ Snapshot options can be passed when calling the snapshot function:
 ```ts
 await expect(
   snapshotElement(page.getByLabel("My select"), {
-    includeComboboxOptions: true,
+    filter: (element) => element.role === "heading",
   }),
 ).toMatchJsonFile({
-  name: "select options",
+  name: "headings",
 });
 ```
+
+| Option                   | Default Value | Description                                                                          |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------------ |
+| `filter`                 | `() => true`  | Include only elements in the snapshot for which the specified filter returns `true`. |
+| `includeComboboxOptions` | `false`       | Include combobox options in the snapshot.                                            |
 
 ### Custom Snapshots
 

--- a/packages/element-snapshot/src/playwright/snapshot.ts
+++ b/packages/element-snapshot/src/playwright/snapshot.ts
@@ -3,9 +3,17 @@ import type { Locator } from "@playwright/test";
 import type { NodeSnapshot } from "../browser/types";
 
 import { ElementSnapshotProxy } from "./proxy";
+import type { SnapshotFilter } from "./transformer";
 import { ElementSnapshotTransformer } from "./transformer";
 
 export interface ElementSnapshotOptions {
+  /**
+   * Include only elements in the snapshot for which the specified filter returns `true`
+   *
+   * @default () => true
+   */
+  filter?: SnapshotFilter;
+
   /**
    * Include combobox options in the snapshot
    *

--- a/packages/playwright-file-snapshots/data/test/validation/snapshots/filter_elements/headings.json
+++ b/packages/playwright-file-snapshots/data/test/validation/snapshots/filter_elements/headings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "heading": {
+      "name": "HTML Test Document",
+      "level": 1
+    }
+  },
+  {
+    "heading": {
+      "name": "Unnamed Section",
+      "level": 2
+    }
+  },
+  {
+    "heading": {
+      "name": "Article",
+      "level": 3
+    }
+  },
+  {
+    "heading": {
+      "name": "Aside",
+      "level": 2
+    }
+  }
+]

--- a/packages/playwright-file-snapshots/tests/snapshots.spec.ts
+++ b/packages/playwright-file-snapshots/tests/snapshots.spec.ts
@@ -142,3 +142,12 @@ test("progressbars", async ({ page }) => {
   await page.goto("/progressbars");
   await testSnapshots(page.getByRole("main"));
 });
+
+test("filter elements", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    snapshotElement(page.locator("body"), {
+      filter: (element) => element.role === "heading",
+    }),
+  ).toMatchJsonFile({ name: "headings" });
+});


### PR DESCRIPTION
This PRs adds support for specifying an optional filter function for element snapshots. The filter is based on the complete element snapshot, enabling a lot of flexibility. For example, elements can be filtered by their role or role-dependent attributes, and filters can be both inclusive or exclusive.

Possible use cases are filtering only specifics elements (e.g. headings) or excluding elements which are not relevant to the test but make the snapshot more verbose (e.g. separators).