### PR TITLE
feat(playwright): Introduce role `descriptionlist` for `<dl>` element

### DIFF
--- a/.changeset/eager-tires-cheer.md
+++ b/.changeset/eager-tires-cheer.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Introduce role `descriptionlist` for HTML description list element

--- a/packages/element-snapshot/data/test/validation/elements/description-list/HTML_description_list.json
+++ b/packages/element-snapshot/data/test/validation/elements/description-list/HTML_description_list.json
@@ -1,46 +1,51 @@
 [
   {
-    "role": "term",
+    "role": "descriptionlist",
     "children": [
       {
-        "role": "text",
-        "name": "Coffee"
-      }
-    ]
-  },
-  {
-    "role": "definition",
-    "children": [
+        "role": "term",
+        "children": [
+          {
+            "role": "text",
+            "name": "Coffee"
+          }
+        ]
+      },
       {
-        "role": "text",
-        "name": "A brewed drink prepared from roasted coffee beans"
-      }
-    ]
-  },
-  {
-    "role": "term",
-    "children": [
+        "role": "definition",
+        "children": [
+          {
+            "role": "text",
+            "name": "A brewed drink prepared from roasted coffee beans"
+          }
+        ]
+      },
       {
-        "role": "text",
-        "name": "Tea"
-      }
-    ]
-  },
-  {
-    "role": "definition",
-    "children": [
+        "role": "term",
+        "children": [
+          {
+            "role": "text",
+            "name": "Tea"
+          }
+        ]
+      },
       {
-        "role": "text",
-        "name": "A beverage made by steeping dried leaves in hot water"
-      }
-    ]
-  },
-  {
-    "role": "definition",
-    "children": [
+        "role": "definition",
+        "children": [
+          {
+            "role": "text",
+            "name": "A beverage made by steeping dried leaves in hot water"
+          }
+        ]
+      },
       {
-        "role": "text",
-        "name": "An afternoon meal or social gathering, typically in British culture"
+        "role": "definition",
+        "children": [
+          {
+            "role": "text",
+            "name": "An afternoon meal or social gathering, typically in British culture"
+          }
+        ]
       }
     ]
   }

--- a/packages/element-snapshot/data/test/validation/elements/description-list/empty_definition.json
+++ b/packages/element-snapshot/data/test/validation/elements/description-list/empty_definition.json
@@ -1,5 +1,10 @@
 [
   {
-    "role": "definition"
+    "role": "descriptionlist",
+    "children": [
+      {
+        "role": "definition"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/test/validation/elements/description-list/empty_description_list.json
+++ b/packages/element-snapshot/data/test/validation/elements/description-list/empty_description_list.json
@@ -1,1 +1,5 @@
-[]
+[
+  {
+    "role": "descriptionlist"
+  }
+]

--- a/packages/element-snapshot/data/test/validation/elements/description-list/empty_term.json
+++ b/packages/element-snapshot/data/test/validation/elements/description-list/empty_term.json
@@ -1,5 +1,10 @@
 [
   {
-    "role": "term"
+    "role": "descriptionlist",
+    "children": [
+      {
+        "role": "term"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/test/validation/elements/description-list/role-based_description_list.json
+++ b/packages/element-snapshot/data/test/validation/elements/description-list/role-based_description_list.json
@@ -1,19 +1,24 @@
 [
   {
-    "role": "term",
+    "role": "descriptionlist",
     "children": [
       {
-        "role": "text",
-        "name": "Coffee"
-      }
-    ]
-  },
-  {
-    "role": "definition",
-    "children": [
+        "role": "term",
+        "children": [
+          {
+            "role": "text",
+            "name": "Coffee"
+          }
+        ]
+      },
       {
-        "role": "text",
-        "name": "A brewed drink prepared from roasted coffee beans"
+        "role": "definition",
+        "children": [
+          {
+            "role": "text",
+            "name": "A brewed drink prepared from roasted coffee beans"
+          }
+        ]
       }
     ]
   }

--- a/packages/element-snapshot/src/browser/container.ts
+++ b/packages/element-snapshot/src/browser/container.ts
@@ -20,6 +20,7 @@ const CONTAINER_ROLES = new Set([
   "navigation",
   "region",
   "search",
+  "descriptionlist",
   "term",
   "definition",
   "table",

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -42,6 +42,7 @@ const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   textarea: "textbox",
   select: "combobox",
   option: "option",
+  dl: "descriptionlist",
   dt: "term",
   dd: "definition",
   table: "table",


### PR DESCRIPTION
The HTML [`<dl>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) has no associated ARIA role. However, most browsers use a synthetic role like `descriptionlist` to represent `<dl>` elements in the a11y tree. This retains the grouping described by `<dl>` elements, which is also useful for processing Element Snapshots programmatically. For this reason, this PR introduces the synthetic role `descriptionlist` to represent `<dl>` elements in snapshots.

Closes #297 