### PR TITLE
Migrate from tsc to tsgo

### DIFF
--- a/.meta-updater/main.mjs
+++ b/.meta-updater/main.mjs
@@ -122,7 +122,7 @@ function updateScripts(scripts, packageDir) {
     ...scripts,
     "lint:check": `eslint ${lintedDirs} --max-warnings=0`,
     "lint:fix": `eslint ${lintedDirs} --max-warnings=0 --fix`,
-    compile: "tsc",
+    compile: "tsgo",
   };
 }
 
@@ -136,13 +136,13 @@ function updateDevDependencies(devDependencies) {
     ...devDependencies,
     "@arethetypeswrong/core": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     eslint: "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     prettier: "catalog:",
     publint: "catalog:",
     tsdown: "catalog:",
-    typescript: "catalog:",
     "typescript-eslint": "catalog:",
   };
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "eslint.workingDirectories": [{ "mode": "auto" }]
+  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "typescript.experimental.useTsgo": true
 }

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -36,7 +36,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:integration": "playwright test",
     "playwright:install": "playwright install chromium",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown"
   },
   "type": "module",
@@ -60,6 +60,7 @@
     "@cronn/test-utils": "workspace:*",
     "@playwright/test": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
@@ -68,7 +69,6 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/element-snapshot/package.json
+++ b/packages/element-snapshot/package.json
@@ -36,7 +36,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:integration": "playwright test",
     "playwright:install": "playwright install chromium",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown"
   },
   "type": "module",
@@ -60,6 +60,7 @@
     "@cronn/test-utils": "workspace:*",
     "@playwright/test": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
@@ -68,7 +69,6 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown"
   },
   "type": "module",
@@ -55,6 +55,7 @@
     "@arethetypeswrong/core": "catalog:",
     "@cronn/shared-configs": "workspace:*",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
@@ -63,7 +64,6 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -43,7 +43,7 @@
     "test:integration:update-changed": "playwright test --grep @update-changed --update-snapshots changed",
     "test:integration:update-none": "playwright test --grep @update-none --update-snapshots none",
     "playwright:install": "playwright install chromium",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown"
   },
   "type": "module",
@@ -66,6 +66,7 @@
     "@cronn/shared-configs": "workspace:*",
     "@playwright/test": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
@@ -74,7 +75,6 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "lint:check": "eslint src/ --max-warnings=0",
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown --config-loader unrun"
   },
   "type": "module",
@@ -55,12 +55,12 @@
   "devDependencies": {
     "@playwright/test": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "lint:check": "eslint src/ --max-warnings=0",
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown"
   },
   "type": "module",
@@ -44,12 +44,12 @@
     "@cronn/shared-configs": "workspace:*",
     "@playwright/test": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:"
   }
 }

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -41,7 +41,7 @@
     "test:update-all": "cross-env UPDATE_TYPE=all CI=false GITHUB_ACTIONS= vitest run --update ./__tests__/update-snapshot.test.ts",
     "test:update-none": "cross-env UPDATE_TYPE=none CI=true vitest run ./__tests__/update-snapshot.test.ts",
     "test:coverage": "vitest run --coverage",
-    "compile": "tsc",
+    "compile": "tsgo",
     "build": "tsdown && node scripts/fix-declaration-file.ts"
   },
   "type": "module",
@@ -62,6 +62,7 @@
     "@arethetypeswrong/core": "catalog:",
     "@cronn/shared-configs": "workspace:*",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/expect": "catalog:",
@@ -73,7 +74,6 @@
     "prettier": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@types/node':
       specifier: 24.10.13
       version: 24.10.13
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260218.1
+      version: 7.0.0-dev.20260218.1
     '@vitest/coverage-v8':
       specifier: 4.0.18
       version: 4.0.18
@@ -57,9 +60,6 @@ catalogs:
     turbo:
       specifier: 2.8.10
       version: 2.8.10
-    typescript:
-      specifier: 5.9.3
-      version: 5.9.3
     typescript-eslint:
       specifier: 8.56.0
       version: 8.56.0
@@ -125,6 +125,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))
@@ -145,10 +148,7 @@ importers:
         version: 0.3.17
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -183,6 +183,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))
@@ -203,10 +206,7 @@ importers:
         version: 0.3.17
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -228,6 +228,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))
@@ -248,10 +251,7 @@ importers:
         version: 0.3.17
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -283,6 +283,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))
@@ -303,10 +306,7 @@ importers:
         version: 0.3.17
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -322,6 +322,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 'catalog:'
         version: 6.0.2(prettier@3.8.1)
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       eslint:
         specifier: 'catalog:'
         version: 10.0.1(jiti@2.5.1)
@@ -336,10 +339,7 @@ importers:
         version: 3.8.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -358,6 +358,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 'catalog:'
         version: 6.0.2(prettier@3.8.1)
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       eslint:
         specifier: 'catalog:'
         version: 10.0.1(jiti@2.5.1)
@@ -372,10 +375,7 @@ importers:
         version: 3.8.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -398,6 +398,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260218.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))
@@ -427,10 +430,7 @@ importers:
         version: 0.3.17
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.56.0(eslint@10.0.1(jiti@2.5.1))(typescript@5.9.3)
@@ -1760,6 +1760,45 @@ packages:
     resolution: {integrity: sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-ybxez4ClJU12TUvX/IxGPIQfS26+Zia7kbB1L4RH+G8yzYg90RPt4njfJkU2WxP70Hp59zS2copPkaBz5gUJkQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-n9Ki8WTW82w6PlBTlrAQAjEUQB2V7C2oXrkN5U7ElwUH4FOostSFzZHuAdnPMbdzMx76P0pEw9FteYrLDA4m9g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-Osus82LSlwi1l3LoxLWKDuxh5E8JyWwkseBjr2n+TMaTuDPcRSzT8Jr4ywIp3NJpCUUV/LzR84i64jA6g8iVIw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-WRPMvTztPatQ91UzYWSp82NT45JmjMgo/pVgZjXYEWdF2rwS4ejzR6DnHq30jXhEPnMah1bTeOzSWFF2kvXUmg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-jcDhKCvhWQyMbra4MiqSgyUoSdM9mAiSkIdc80qScpk03aZOU+BZEmHz51S+fEn+8KRWuMuIHXM3sG3oX/EJZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-VmWvJ+TEuTPmZrhWe+buvvUvHbMyiD4ZLgxYPdYcJ3kRQlk2mD5lOq63ZISx1pDB8kYz5/R5xYKy/8gSIU5MgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-9zfUrKV3xBog2tpIR9NZOags+QJZSj7v9Ek7KdSkVu978IJqF9RX7oa2xftX+eiHySfV5ZQ8r2fdhdbYBk+kMw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260218.1':
+    resolution: {integrity: sha512-hbGRXBk7abFvOQJk/7mc8K9q1kPkiyziyUsS8r8Hc1sLxrDFUbGgsW9p8qg67Xe1K6NUv/9UU2cdeIitUDexIQ==}
+    hasBin: true
+
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
     peerDependencies:
@@ -3007,10 +3046,6 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
-
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
 
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
@@ -5562,6 +5597,37 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260218.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260218.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260218.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260218.1
+
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.5.1)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -6790,10 +6856,6 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
@@ -6983,7 +7045,7 @@ snapshots:
     dependencies:
       glob: 13.0.0
 
-  rolldown-plugin-dts@0.22.1(rolldown@1.0.0-rc.3)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.1(@typescript/native-preview@7.0.0-dev.20260218.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.1
       '@babel/helper-validator-identifier': 8.0.0-rc.1
@@ -6996,6 +7058,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.3
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260218.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -7274,7 +7337,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tsdown@0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(typescript@5.9.3):
+  tsdown@0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260218.1)(publint@0.3.17)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -7285,7 +7348,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
-      rolldown-plugin-dts: 0.22.1(rolldown@1.0.0-rc.3)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260218.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalog:
   "@playwright/test": 1.58.2
   "@pnpm/meta-updater": 2.0.6
   "@trivago/prettier-plugin-sort-imports": 6.0.2
+  "@typescript/native-preview": 7.0.0-dev.20260218.1
   "@types/node": 24.10.13
   "@vitest/coverage-v8": 4.0.18
   "@vitest/expect": 4.0.18
@@ -19,7 +20,6 @@ catalog:
   "publint": 0.3.17
   "tsdown": 0.20.3
   "turbo": 2.8.10
-  "typescript": 5.9.3
   "typescript-eslint": 8.56.0
   "vitest": 4.0.18
   "yaml": 2.8.2


### PR DESCRIPTION
This PR migrates the TypeScript compiler checks from tsc to [tsgo](https://github.com/microsoft/typescript-go).
tsgo is still in preview, but seems stable enough by now to use in a non-critical environment like this monorepo.

The differences in compile times are significant, but not relevant due to the still relatively small size of packages. Running `tsc` on all packages took around 2.5 s on average, while running `tsgo` took around 1 s on average. tsgo works both in VS Code and IntelliJ IDEA, and yields a more responsive developer experience. The differences will be more noticeable when the package sizes further increase.

Switching to `tsgo` is mostly for testing out the new compiler and evaluating its use for other projects. The switch does not affect the package output, because `tsgo` is only used for type checking while the build output is generated by `tsdown`.