### PR TITLE
feat(element-snapshot): Export filter predicates

### DIFF
--- a/.changeset/dull-grapes-exist.md
+++ b/.changeset/dull-grapes-exist.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Export filter predicates `includeRole` and `excludeRole`

--- a/packages/element-snapshot/README.md
+++ b/packages/element-snapshot/README.md
@@ -113,3 +113,11 @@ function transformToMarkdownTable(snapshot: Array<NodeSnapshot>): string {
   // transform table snapshot to markdown table
 }
 ```
+
+#### Utility Functions for Custom Snapshots
+
+| Function      | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `filter`      | Filters node snapshots based on the provided predicate function. |
+| `includeRole` | Includes only elements with the specified role.                  |
+| `excludeRole` | Excludes elements with the specified role.                       |

--- a/packages/element-snapshot/src/__tests__/guards.test.ts
+++ b/packages/element-snapshot/src/__tests__/guards.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 
-import { isEmpty, isTextSnapshot } from "../utils/guards";
+import type { ElementSnapshot } from "../browser/types";
+import { elementSnapshot } from "../utils/factories";
+import { hasRole, isEmpty, isTextSnapshot } from "../utils/guards";
 
 describe("isTextSnapshot", () => {
   test("when value is text snapshot, returns true", () => {
@@ -11,6 +13,28 @@ describe("isTextSnapshot", () => {
     expect(isTextSnapshot({ role: "main", attributes: {}, children: [] })).toBe(
       false,
     );
+  });
+});
+
+describe("hasRole", () => {
+  const paragraphSnapshot: ElementSnapshot = elementSnapshot({
+    role: "paragraph",
+  });
+
+  test("when snapshot has provided role, returns true", () => {
+    expect(hasRole("paragraph", paragraphSnapshot)).toBe(true);
+  });
+
+  test("when snapshot has any of the provided roles, returns true", () => {
+    expect(hasRole(["heading", "paragraph"], paragraphSnapshot)).toBe(true);
+  });
+
+  test("when snapshot does not have the provided role, returns false", () => {
+    expect(hasRole("heading", paragraphSnapshot)).toBe(false);
+  });
+
+  test("when snapshot has none of the provided roles, returns false", () => {
+    expect(hasRole(["heading", "list"], paragraphSnapshot)).toBe(false);
   });
 });
 

--- a/packages/element-snapshot/src/__tests__/predicates.test.ts
+++ b/packages/element-snapshot/src/__tests__/predicates.test.ts
@@ -10,13 +10,13 @@ describe("includeRole", () => {
   });
 
   test("when snapshot has provided role, returns true", () => {
-    const hasRoleParagraph = includeRole("paragraph");
-    expect(hasRoleParagraph(paragraphSnapshot)).toBe(true);
+    const includeParagraph = includeRole("paragraph");
+    expect(includeParagraph(paragraphSnapshot)).toBe(true);
   });
 
-  test("when snapshot has different role, returns false", () => {
-    const hasRoleList = includeRole("list");
-    expect(hasRoleList(paragraphSnapshot)).toBe(false);
+  test("when snapshot does not have provided role, returns false", () => {
+    const includeHeading = includeRole("heading");
+    expect(includeHeading(paragraphSnapshot)).toBe(false);
   });
 });
 
@@ -26,12 +26,12 @@ describe("excludeRole", () => {
   });
 
   test("when snapshot has provided role, returns false", () => {
-    const hasRoleParagraph = excludeRole("paragraph");
-    expect(hasRoleParagraph(paragraphSnapshot)).toBe(false);
+    const excludeParagraph = excludeRole("paragraph");
+    expect(excludeParagraph(paragraphSnapshot)).toBe(false);
   });
 
-  test("when snapshot has different role, returns true", () => {
-    const hasRoleList = excludeRole("list");
-    expect(hasRoleList(paragraphSnapshot)).toBe(true);
+  test("when snapshot does not have provided role, returns true", () => {
+    const excludeHeading = excludeRole("heading");
+    expect(excludeHeading(paragraphSnapshot)).toBe(true);
   });
 });

--- a/packages/element-snapshot/src/index.ts
+++ b/packages/element-snapshot/src/index.ts
@@ -24,3 +24,4 @@ export type { ColumnheaderSnapshot } from "./browser/table";
 export { snapshotElement, snapshotElementRaw } from "./playwright/snapshot";
 
 export { filter } from "./utils/filter";
+export { includeRole, excludeRole } from "./utils/predicates";

--- a/packages/element-snapshot/src/utils/guards.ts
+++ b/packages/element-snapshot/src/utils/guards.ts
@@ -1,10 +1,22 @@
 import type { TextSnapshot } from "../browser/text";
-import type { NodeSnapshot } from "../browser/types";
+import type { NodeRole, NodeSnapshot } from "../browser/types";
+import type { SnapshotByRole } from "../types/snapshot";
 
 export function isTextSnapshot(
   snapshot: NodeSnapshot,
 ): snapshot is TextSnapshot {
-  return snapshot.role === "text";
+  return hasRole("text", snapshot);
+}
+
+export function hasRole<TRole extends NodeRole>(
+  role: TRole | Array<TRole>,
+  snapshot: NodeSnapshot,
+): snapshot is SnapshotByRole<TRole> {
+  if (typeof role === "string") {
+    return role === snapshot.role;
+  }
+
+  return role.includes(snapshot.role as TRole);
 }
 
 export function isEmpty(

--- a/packages/element-snapshot/src/utils/predicates.ts
+++ b/packages/element-snapshot/src/utils/predicates.ts
@@ -2,17 +2,23 @@ import type { NodeRole, NodeSnapshot } from "../browser/types";
 import type { SnapshotByRole } from "../types/snapshot";
 
 import type { GuardedFilterPredicate } from "./filter";
+import { hasRole } from "./guards";
 
+/**
+ * Include only elements with the specified role
+ */
 export function includeRole<TRole extends NodeRole>(
-  role: TRole,
+  role: TRole | Array<TRole>,
 ): GuardedFilterPredicate<SnapshotByRole<TRole>> {
-  return (snapshot: NodeSnapshot): snapshot is SnapshotByRole<TRole> =>
-    snapshot.role === role;
+  return (snapshot: NodeSnapshot) => hasRole(role, snapshot);
 }
 
+/**
+ * Exclude elements with the specified role
+ */
 export function excludeRole<TRole extends NodeRole>(
-  role: TRole,
+  role: TRole | Array<TRole>,
 ): GuardedFilterPredicate<SnapshotByRole<TRole>> {
   return (snapshot: NodeSnapshot): snapshot is SnapshotByRole<TRole> =>
-    snapshot.role !== role;
+    !hasRole(role, snapshot);
 }

--- a/packages/element-snapshot/tests/readable-snapshot/filter.spec.ts
+++ b/packages/element-snapshot/tests/readable-snapshot/filter.spec.ts
@@ -3,6 +3,7 @@ import test from "@playwright/test";
 import { html } from "@cronn/test-utils/playwright";
 
 import { setupTransformedSnapshotTest } from "../../src/test/fixtures";
+import { excludeRole, includeRole } from "../../src/utils/predicates";
 
 test("includes list elements", async ({ page }) => {
   const matchSnapshot = await setupTransformedSnapshotTest(
@@ -25,7 +26,7 @@ test("includes list elements", async ({ page }) => {
   );
 
   await matchSnapshot({
-    filter: (element) => element.role === "list",
+    filter: includeRole("list"),
   });
 });
 
@@ -50,7 +51,7 @@ test("excludes paragraph elements", async ({ page }) => {
   );
 
   await matchSnapshot({
-    filter: (element) => element.role !== "paragraph",
+    filter: excludeRole("paragraph"),
     recurseFilter: true,
   });
 });


### PR DESCRIPTION
This PR export the filter predicates `includeRole` and `excludeRole` to simplify processing of custom snapshots.