### PR TITLE
Remove `canSerialize` method from serializers

### DIFF
--- a/.changeset/easy-owls-chew.md
+++ b/.changeset/easy-owls-chew.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": patch
+---
+
+Remove `canSerialize` method from serializers

--- a/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
+++ b/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
@@ -43,10 +43,6 @@ export class ValidationFileMatcher {
   }
 
   public matchFileSnapshot(actual: unknown): ValidationFileMatcherResult {
-    if (!this.serializer.canSerialize(actual)) {
-      throw new Error(`Cannot serialize value of type ${typeof actual}`);
-    }
-
     const serializedActual = this.serializer.serialize(actual);
     const expected = this.resolveExpected(serializedActual);
 

--- a/packages/lib-file-snapshots/src/serializers/json-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/json-serializer.ts
@@ -65,10 +65,6 @@ export class JsonSerializer implements SnapshotSerializer {
     this.indentSize = options.indentSize ?? 2;
   }
 
-  public canSerialize(_value: unknown): boolean {
-    return true;
-  }
-
   public serialize(value: unknown): string {
     const jsonValue = this.normalizeValueRecursive(value);
     const jsonString = JSON.stringify(jsonValue, undefined, this.indentSize);

--- a/packages/lib-file-snapshots/src/serializers/text-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/text-serializer.ts
@@ -28,14 +28,10 @@ export class TextSerializer implements SnapshotSerializer {
     this.fileExtension = options.fileExtension ?? "txt";
   }
 
-  public canSerialize(value: unknown): value is string {
-    return isString(value);
-  }
-
   public serialize(value: unknown): string {
-    if (!this.canSerialize(value)) {
+    if (!isString(value)) {
       throw new Error(
-        `Missing text serialization for value of type ${typeof value}.`,
+        `Value of type ${typeof value} cannot be serialized as text. Only strings are supported.`,
       );
     }
 

--- a/packages/lib-file-snapshots/src/types/serializer.ts
+++ b/packages/lib-file-snapshots/src/types/serializer.ts
@@ -5,13 +5,6 @@ export interface SnapshotSerializer {
   readonly fileExtension: string;
 
   /**
-   * Returns true when value can be serialized
-   *
-   * @param value The value to be serialized
-   */
-  canSerialize(value: unknown): boolean;
-
-  /**
    * Serializes value
    *
    * @param value The value to be serialized

--- a/packages/lib-file-snapshots/src/utils/test.ts
+++ b/packages/lib-file-snapshots/src/utils/test.ts
@@ -20,7 +20,6 @@ export function testSerializer(
     const serializedValue = serializer.serialize(value);
     const normalizedTestName = normalizeFileName(testName);
 
-    expect(serializer.canSerialize(value)).toBe(true);
     await expect(serializedValue).toMatchFileSnapshot(
       path.join(
         ".",
@@ -37,7 +36,6 @@ export function testSerializerThrows(
   value: unknown,
 ): () => void {
   return (): void => {
-    expect(serializer.canSerialize(value)).toBe(false);
     expect(() => serializer.serialize(value)).toThrowError();
   };
 }


### PR DESCRIPTION
The validation is now performed directly in the serialize method, simplifying the interface and eliminating redundant checks.