### PR TITLE
Export `markdownTableSnapshot` function

### DIFF
--- a/.changeset/young-mammals-kiss.md
+++ b/.changeset/young-mammals-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": patch
+---
+
+Export `markdownTableSnapshot` function

--- a/packages/element-snapshot/src/index.ts
+++ b/packages/element-snapshot/src/index.ts
@@ -21,6 +21,7 @@ export type { SeparatorSnapshot } from "./browser/separator";
 export type { TabSnapshot } from "./browser/tab";
 export type { ColumnheaderSnapshot } from "./browser/table";
 
+export { markdownTableSnapshot } from "./playwright/markdown-table";
 export { snapshotElement, snapshotElementRaw } from "./playwright/snapshot";
 
 export { filter, filterByRole } from "./utils/filter";


### PR DESCRIPTION
This PR adds the `markdownTableSnapshot` to the export. It was previously missing.