### PR TITLE
Merge consecutive text nodes

### DIFF
--- a/.changeset/sharp-lines-wonder.md
+++ b/.changeset/sharp-lines-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Merge consecutive text nodes in snapshots

--- a/packages/element-snapshot/data/integration-test/validation/elements/grid/ignores_cells_outside_grid.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/grid/ignores_cells_outside_grid.json
@@ -1,14 +1,6 @@
 [
   {
     "role": "text",
-    "name": "Column Header"
-  },
-  {
-    "role": "text",
-    "name": "Row Header"
-  },
-  {
-    "role": "text",
-    "name": "Grid Cell"
+    "name": "Column Header Row Header Grid Cell"
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/grid/ignores_cells_outside_row.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/grid/ignores_cells_outside_row.json
@@ -5,15 +5,7 @@
     "children": [
       {
         "role": "text",
-        "name": "Column Header"
-      },
-      {
-        "role": "text",
-        "name": "Row Header"
-      },
-      {
-        "role": "text",
-        "name": "Grid Cell"
+        "name": "Column Header Row Header Grid Cell"
       }
     ]
   }

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
@@ -6,11 +6,7 @@
     "children": [
       {
         "role": "text",
-        "name": "Legend"
-      },
-      {
-        "role": "text",
-        "name": "First Name"
+        "name": "Legend First Name"
       },
       {
         "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/ignores_cells_outside_row.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/ignores_cells_outside_row.json
@@ -5,15 +5,7 @@
     "children": [
       {
         "role": "text",
-        "name": "Column Header"
-      },
-      {
-        "role": "text",
-        "name": "Row Header"
-      },
-      {
-        "role": "text",
-        "name": "Cell"
+        "name": "Column Header Row Header Cell"
       }
     ]
   }

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/ignores_cells_outside_table.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/ignores_cells_outside_table.json
@@ -1,14 +1,6 @@
 [
   {
     "role": "text",
-    "name": "Column Header"
-  },
-  {
-    "role": "text",
-    "name": "Row Header"
-  },
-  {
-    "role": "text",
-    "name": "Cell"
+    "name": "Column Header Row Header Cell"
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/text/consecutive_text_nodes.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/text/consecutive_text_nodes.json
@@ -1,0 +1,15 @@
+[
+  {
+    "role": "text",
+    "name": "First Second"
+  },
+  {
+    "role": "separator",
+    "attributes": {},
+    "children": []
+  },
+  {
+    "role": "text",
+    "name": "Third Fourth"
+  }
+]

--- a/packages/element-snapshot/src/__tests__/text-utils.test.ts
+++ b/packages/element-snapshot/src/__tests__/text-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { elementSnapshot, textSnapshot } from "../utils/factories";
-import { getTextContent, normalizeText } from "../utils/text";
+import { getTextContent, mergeTexts, normalizeText } from "../utils/text";
 
 describe("getTextContent", () => {
   test("returns text from text snapshots only", () => {
@@ -37,5 +37,19 @@ describe("normalizeText", () => {
 
   test("replaces multiple infix whitespaces by single whitespace", () => {
     expect(normalizeText("word1 \t\r\n\v\f word2")).toBe("word1 word2");
+  });
+});
+
+describe("mergeTexts", () => {
+  test("concatenates text snapshots", () => {
+    expect(mergeTexts([textSnapshot("word1"), textSnapshot("word2")])).toBe(
+      "word1 word2",
+    );
+  });
+
+  test("normalizes merged text", () => {
+    expect(mergeTexts([textSnapshot(" word1"), textSnapshot(" word2 ")])).toBe(
+      "word1 word2",
+    );
   });
 });

--- a/packages/element-snapshot/src/browser/children.ts
+++ b/packages/element-snapshot/src/browser/children.ts
@@ -1,3 +1,7 @@
+import { textSnapshot } from "../utils/factories";
+import { isTextSnapshot } from "../utils/guards";
+import { mergeTexts } from "../utils/text";
+
 import { snapshotNodeRecursive } from "./element";
 import type { NodeSnapshot } from "./types";
 
@@ -9,5 +13,29 @@ export function snapshotChildren(
     .map((childNode) => snapshotNodeRecursive(childNode, excludedNodes))
     .filter((childSnapshot) => childSnapshot !== null)
     .flat();
-  return children;
+
+  return mergeConsecutiveTexts(children);
+}
+
+function mergeConsecutiveTexts(
+  children: Array<NodeSnapshot>,
+): Array<NodeSnapshot> {
+  return children.reduce<Array<NodeSnapshot>>((mergedChildren, child) => {
+    const lastMergedChildIndex = mergedChildren.length - 1;
+    const lastMergedChild = mergedChildren[lastMergedChildIndex];
+
+    if (
+      lastMergedChild !== undefined &&
+      isTextSnapshot(lastMergedChild) &&
+      isTextSnapshot(child)
+    ) {
+      mergedChildren[lastMergedChildIndex] = textSnapshot(
+        mergeTexts([lastMergedChild, child]),
+      );
+    } else {
+      mergedChildren.push(child);
+    }
+
+    return mergedChildren;
+  }, []);
 }

--- a/packages/element-snapshot/src/utils/text.ts
+++ b/packages/element-snapshot/src/utils/text.ts
@@ -1,3 +1,4 @@
+import type { TextSnapshot } from "../browser/text";
 import type { NodeSnapshot } from "../browser/types";
 
 import { filter } from "./filter";
@@ -7,15 +8,19 @@ import { isTextSnapshot } from "./guards";
  * Aggregates and normalizes the text content of all provided snapshots
  */
 export function getTextContent(snapshots: Array<NodeSnapshot>): string {
-  const textNodes = filter({
+  const texts = filter({
     snapshots,
     predicate: isTextSnapshot,
   });
 
-  const aggregatedText = textNodes.map((textNode) => textNode.name).join(" ");
-  return normalizeText(aggregatedText);
+  return mergeTexts(texts);
 }
 
 export function normalizeText(text: string): string {
   return text.replaceAll(/\s+/g, " ").trim();
+}
+
+export function mergeTexts(texts: Array<TextSnapshot>): string {
+  const mergedText = texts.map((textNode) => textNode.name).join(" ");
+  return normalizeText(mergedText);
 }

--- a/packages/element-snapshot/tests/elements/text.spec.ts
+++ b/packages/element-snapshot/tests/elements/text.spec.ts
@@ -33,3 +33,12 @@ test("empty paragraph", async ({ page }) => {
 test("HTML span", async ({ page }) => {
   await matchRawElementSnapshot(page, html`<span>Span</span>`);
 });
+
+test("consecutive text nodes", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`<span>First</span><span>Second</span>
+      <hr />
+      <span>Third</span><span>Fourth</span>`,
+  );
+});


### PR DESCRIPTION
Consecutive text nodes are now automatically merged into a single text snapshot during children processing. This simplifies snapshot structure and improves readability when multiple adjacent text elements are present.

Note: As a result of this change, texts from label elements will be merged with other text nodes, which might be less readable. In #271, label elements will be assigned a distinct role. This allows to serialize them separated from normal texts nodes.

Closes #345 