### PR TITLE
Add label role for `label` and `legend` elements

### DIFF
--- a/.changeset/lemon-canyons-know.md
+++ b/.changeset/lemon-canyons-know.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add label role for `label` and `legend` elements

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-label_takes_precedence_over_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-label_takes_precedence_over_HTML_label.json
@@ -10,13 +10,20 @@
     ]
   },
   {
-    "role": "textbox",
-    "name": "Direct Label",
+    "role": "label",
+    "name": "HTML Label",
     "attributes": {},
-    "children": []
-  },
-  {
-    "role": "text",
-    "name": "HTML Label"
+    "children": [
+      {
+        "role": "textbox",
+        "name": "Direct Label",
+        "attributes": {},
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "HTML Label"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-labelledby_takes_precedence_over_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-labelledby_takes_precedence_over_HTML_label.json
@@ -10,13 +10,20 @@
     ]
   },
   {
-    "role": "textbox",
-    "name": "Referenced Label",
+    "role": "label",
+    "name": "HTML Label",
     "attributes": {},
-    "children": []
-  },
-  {
-    "role": "text",
-    "name": "HTML Label"
+    "children": [
+      {
+        "role": "textbox",
+        "name": "Referenced Label",
+        "attributes": {},
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "HTML Label"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/referenced_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/referenced_HTML_label.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Label"
+    "role": "label",
+    "name": "Label",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Label"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/surrounding_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/surrounding_HTML_label.json
@@ -1,12 +1,19 @@
 [
   {
-    "role": "checkbox",
+    "role": "label",
     "name": "Label",
     "attributes": {},
-    "children": []
-  },
-  {
-    "role": "text",
-    "name": "Label"
+    "children": [
+      {
+        "role": "checkbox",
+        "name": "Label",
+        "attributes": {},
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "Label"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
@@ -5,8 +5,26 @@
     "attributes": {},
     "children": [
       {
-        "role": "text",
-        "name": "Legend First Name"
+        "role": "label",
+        "name": "Legend",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "Legend"
+          }
+        ]
+      },
+      {
+        "role": "label",
+        "name": "First Name",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "First Name"
+          }
+        ]
       },
       {
         "role": "textbox",
@@ -15,8 +33,15 @@
         "children": []
       },
       {
-        "role": "text",
-        "name": "Last Name"
+        "role": "label",
+        "name": "Last Name",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "Last Name"
+          }
+        ]
       },
       {
         "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/radiogroup.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/radiogroup.json
@@ -30,24 +30,38 @@
         ]
       },
       {
-        "role": "radio",
+        "role": "label",
         "name": "Option 1",
         "attributes": {},
-        "children": []
+        "children": [
+          {
+            "role": "radio",
+            "name": "Option 1",
+            "attributes": {},
+            "children": []
+          },
+          {
+            "role": "text",
+            "name": "Option 1"
+          }
+        ]
       },
       {
-        "role": "text",
-        "name": "Option 1"
-      },
-      {
-        "role": "radio",
+        "role": "label",
         "name": "Option 2",
         "attributes": {},
-        "children": []
-      },
-      {
-        "role": "text",
-        "name": "Option 2"
+        "children": [
+          {
+            "role": "radio",
+            "name": "Option 2",
+            "attributes": {},
+            "children": []
+          },
+          {
+            "role": "text",
+            "name": "Option 2"
+          }
+        ]
       }
     ]
   }

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/role-based-group_without_name.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/role-based-group_without_name.json
@@ -4,8 +4,15 @@
     "attributes": {},
     "children": [
       {
-        "role": "text",
-        "name": "First Name"
+        "role": "label",
+        "name": "First Name",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "First Name"
+          }
+        ]
       },
       {
         "role": "textbox",
@@ -14,8 +21,15 @@
         "children": []
       },
       {
-        "role": "text",
-        "name": "Last Name"
+        "role": "label",
+        "name": "Last Name",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "Last Name"
+          }
+        ]
       },
       {
         "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
@@ -1,37 +1,44 @@
 [
   {
-    "role": "text",
-    "name": "Combobox"
-  },
-  {
-    "role": "combobox",
+    "role": "label",
     "name": "Combobox",
-    "attributes": {
-      "value": "Input Value"
-    },
-    "children": [],
-    "options": [
+    "attributes": {},
+    "children": [
       {
-        "role": "option",
-        "name": "Option 1",
-        "attributes": {
-          "selected": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 1"
-          }
-        ]
+        "role": "text",
+        "name": "Combobox"
       },
       {
-        "role": "option",
-        "name": "Option 2",
-        "attributes": {},
-        "children": [
+        "role": "combobox",
+        "name": "Combobox",
+        "attributes": {
+          "value": "Input Value"
+        },
+        "children": [],
+        "options": [
           {
-            "role": "text",
-            "name": "Option 2"
+            "role": "option",
+            "name": "Option 1",
+            "attributes": {
+              "selected": true
+            },
+            "children": [
+              {
+                "role": "text",
+                "name": "Option 1"
+              }
+            ]
+          },
+          {
+            "role": "option",
+            "name": "Option 2",
+            "attributes": {},
+            "children": [
+              {
+                "role": "text",
+                "name": "Option 2"
+              }
+            ]
           }
         ]
       }

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_checkbox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_checkbox.json
@@ -1,24 +1,38 @@
 [
   {
-    "role": "checkbox",
+    "role": "label",
     "name": "Checked",
-    "attributes": {
-      "checked": true
-    },
-    "children": []
+    "attributes": {},
+    "children": [
+      {
+        "role": "checkbox",
+        "name": "Checked",
+        "attributes": {
+          "checked": true
+        },
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "Checked"
+      }
+    ]
   },
   {
-    "role": "text",
-    "name": "Checked"
-  },
-  {
-    "role": "checkbox",
+    "role": "label",
     "name": "Unchecked",
     "attributes": {},
-    "children": []
-  },
-  {
-    "role": "text",
-    "name": "Unchecked"
+    "children": [
+      {
+        "role": "checkbox",
+        "name": "Unchecked",
+        "attributes": {},
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "Unchecked"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_date_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_date_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Date Input"
+    "role": "label",
+    "name": "Date Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Date Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_email_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_email_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Email Input"
+    "role": "label",
+    "name": "Email Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Email Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_file_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_file_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "File Input"
+    "role": "label",
+    "name": "File Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "File Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Multi Select"
+    "role": "label",
+    "name": "Multi Select",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Multi Select"
+      }
+    ]
   },
   {
     "role": "combobox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_number_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_number_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Number Input"
+    "role": "label",
+    "name": "Number Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Number Input"
+      }
+    ]
   },
   {
     "role": "spinbutton",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_password_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_password_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Password Input"
+    "role": "label",
+    "name": "Password Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Password Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_radio_button.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_radio_button.json
@@ -1,24 +1,38 @@
 [
   {
-    "role": "radio",
+    "role": "label",
     "name": "Yes",
-    "attributes": {
-      "checked": true
-    },
-    "children": []
+    "attributes": {},
+    "children": [
+      {
+        "role": "radio",
+        "name": "Yes",
+        "attributes": {
+          "checked": true
+        },
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "Yes"
+      }
+    ]
   },
   {
-    "role": "text",
-    "name": "Yes"
-  },
-  {
-    "role": "radio",
+    "role": "label",
     "name": "No",
     "attributes": {},
-    "children": []
-  },
-  {
-    "role": "text",
-    "name": "No"
+    "children": [
+      {
+        "role": "radio",
+        "name": "No",
+        "attributes": {},
+        "children": []
+      },
+      {
+        "role": "text",
+        "name": "No"
+      }
+    ]
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_range_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_range_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Range Input"
+    "role": "label",
+    "name": "Range Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Range Input"
+      }
+    ]
   },
   {
     "role": "slider",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_search_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_search_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Search Input"
+    "role": "label",
+    "name": "Search Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Search Input"
+      }
+    ]
   },
   {
     "role": "searchbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Single Select"
+    "role": "label",
+    "name": "Single Select",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Single Select"
+      }
+    ]
   },
   {
     "role": "combobox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_text_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_text_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Text Input"
+    "role": "label",
+    "name": "Text Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Text Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_textarea.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_textarea.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Textarea"
+    "role": "label",
+    "name": "Textarea",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Textarea"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_time_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_time_input.json
@@ -1,7 +1,14 @@
 [
   {
-    "role": "text",
-    "name": "Time Input"
+    "role": "label",
+    "name": "Time Input",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Time Input"
+      }
+    ]
   },
   {
     "role": "textbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
@@ -1,37 +1,44 @@
 [
   {
-    "role": "text",
-    "name": "Combobox"
-  },
-  {
-    "role": "combobox",
+    "role": "label",
     "name": "Combobox",
-    "attributes": {
-      "value": "Input Value"
-    },
-    "children": [],
-    "options": [
+    "attributes": {},
+    "children": [
       {
-        "role": "option",
-        "name": "Option 1",
-        "attributes": {
-          "selected": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 1"
-          }
-        ]
+        "role": "text",
+        "name": "Combobox"
       },
       {
-        "role": "option",
-        "name": "Option 2",
-        "attributes": {},
-        "children": [
+        "role": "combobox",
+        "name": "Combobox",
+        "attributes": {
+          "value": "Input Value"
+        },
+        "children": [],
+        "options": [
           {
-            "role": "text",
-            "name": "Option 2"
+            "role": "option",
+            "name": "Option 1",
+            "attributes": {
+              "selected": true
+            },
+            "children": [
+              {
+                "role": "text",
+                "name": "Option 1"
+              }
+            ]
+          },
+          {
+            "role": "option",
+            "name": "Option 2",
+            "attributes": {},
+            "children": [
+              {
+                "role": "text",
+                "name": "Option 2"
+              }
+            ]
           }
         ]
       }

--- a/packages/element-snapshot/src/browser/container.ts
+++ b/packages/element-snapshot/src/browser/container.ts
@@ -34,7 +34,10 @@ const CONTAINER_ROLES = new Set([
   "menu",
   "tablist",
   "tabpanel",
+  "label",
 ] as const);
+
+const NAMEABLE_CONTAINER_ROLES = new Set(["label"]);
 
 export interface ContainerSnapshot extends GenericElementSnapshot<ContainerRole> {}
 
@@ -48,7 +51,7 @@ export function snapshotContainer(
 
   return {
     role,
-    name: resolveAccessibleName(element, false),
+    name: resolveAccessibleName(element, NAMEABLE_CONTAINER_ROLES.has(role)),
     attributes: {},
     children,
   };

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -56,6 +56,8 @@ const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   progress: "progressbar",
   hr: "separator",
   img: "img",
+  label: "label",
+  legend: "label",
 };
 
 const CONTEXT_DEPENDENT_ROLES: Partial<


### PR DESCRIPTION
This PR adds a "label" role to HTML `<label>` and `<legend>` elements in element snapshots. Previously, these elements were treated as generic text nodes, but now they're explicitly identified with a "label" role, making them distinguishable in snapshots.

The added role also enables targeting of labels in snapshots, e.g. to filter them when they are redundant to the `name` of the corresponding input element.

The role "label" is not part of the ARIA standard, but commonly used as role in the dev tools of web browsers.

This change will be breaking for `snapshotElement`, because labels will now be serialized as `{ "label": "Label" }` instead of just `"Label"`.

Closes #271 