### PR TITLE
vitepress edit links and last updated time

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   base: "/file-snapshots/",
   srcDir: "src",
   cleanUrls: true,
+  lastUpdated: true,
 
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -101,5 +101,11 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/cronn/file-snapshots" },
     ],
+
+    editLink: {
+      pattern:
+        "https://github.com/cronn/file-snapshots/edit/main/packages/docs/src/:path",
+      text: "Edit this page on GitHub",
+    },
   },
 });


### PR DESCRIPTION
Adds an "edit link" and the "last update time" to the bottom of each vitepress document.

<details>

<summary>Screenshot</summary>

<img width="1287" height="850" alt="image" src="https://github.com/user-attachments/assets/22078e44-ecb0-476b-809f-d765c117be6f" />


</details>

