### PR TITLE
docs: Introduce separate pages for file matchers

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -25,46 +25,74 @@ export default defineConfig({
     sidebar: {
       "/playwright/": [
         {
-          text: "Playwright",
+          text: "Playwright File Snapshots",
           items: [
             { text: "Overview", link: "/playwright/" },
             { text: "Getting Started", link: "/playwright/getting-started" },
             { text: "Writing Tests", link: "/playwright/writing-tests" },
             { text: "Configuration", link: "/playwright/configuration" },
             {
-              text: "Element Snapshots",
-              collapsed: true,
+              text: "File Matchers",
+              collapsed: false,
               items: [
                 {
-                  text: "Getting Started",
-                  link: "/playwright/element-snapshots/",
+                  text: "toMatchJsonFile",
+                  link: "/playwright/file-matchers/to-match-json-file",
                 },
                 {
-                  text: "Semantic Snapshots",
-                  link: "/playwright/element-snapshots/semantic-snapshots",
-                },
-                {
-                  text: "Markdown Table Snapshot",
-                  link: "/playwright/element-snapshots/markdown-table-snapshot",
-                },
-                {
-                  text: "Custom Snapshots",
-                  link: "/playwright/element-snapshots/custom-snapshots",
+                  text: "toMatchTextFile",
+                  link: "/playwright/file-matchers/to-match-text-file",
                 },
               ],
             },
-            { text: "ARIA Snapshots", link: "/playwright/aria-snapshots" },
           ],
         },
+        {
+          text: "Element Snapshots",
+          collapsed: false,
+          items: [
+            {
+              text: "Getting Started",
+              link: "/playwright/element-snapshots/",
+            },
+            {
+              text: "Semantic Snapshots",
+              link: "/playwright/element-snapshots/semantic-snapshots",
+            },
+            {
+              text: "Markdown Table Snapshot",
+              link: "/playwright/element-snapshots/markdown-table-snapshot",
+            },
+            {
+              text: "Custom Snapshots",
+              link: "/playwright/element-snapshots/custom-snapshots",
+            },
+          ],
+        },
+        { text: "ARIA Snapshots", link: "/playwright/aria-snapshots" },
       ],
       "/vitest/": [
         {
-          text: "Vitest",
+          text: "Vitest File Snapshots",
           items: [
             { text: "Overview", link: "/vitest/" },
             { text: "Getting Started", link: "/vitest/getting-started" },
             { text: "Writing Tests", link: "/vitest/writing-tests" },
             { text: "Configuration", link: "/vitest/configuration" },
+            {
+              text: "File Matchers",
+              collapsed: false,
+              items: [
+                {
+                  text: "toMatchJsonFile",
+                  link: "/vitest/file-matchers/to-match-json-file",
+                },
+                {
+                  text: "toMatchTextFile",
+                  link: "/vitest/file-matchers/to-match-text-file",
+                },
+              ],
+            },
           ],
         },
       ],

--- a/packages/docs/src/playwright/configuration.md
+++ b/packages/docs/src/playwright/configuration.md
@@ -1,8 +1,6 @@
 # Configuration
 
-## Matcher Options
-
-Matcher options can be passed when defining the matcher:
+Configuration options can be passed when defining the file matchers:
 
 ```ts
 import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
@@ -20,33 +18,3 @@ const expect = defineValidationFileExpect({
 | `indentSize`      | `2`                    | Indentation size in spaces used for serializing snapshots.          |
 | `resolveFileName` | `resolveNameAsFile`    | Custom resolver for the file path used to store snapshots.          |
 | `updateDelay`     | `250`                  | Delay in ms before repeatable snapshots are created in update mode. |
-
-## File Snapshot Options
-
-Snapshot options can be passed whenever calling the validation file matcher:
-
-```ts
-await expect(value).toMatchTextFile({
-  name: "snapshot",
-});
-```
-
-| Option            | Default Value       | Description                                                                                             |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `name`            | `undefined`         | Unique `name` of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. |
-| `normalizers`     | `[]`                | Custom normalizers to apply before serialization.                                                       |
-| `timeout`         | expect timeout      | Retries the snapshot until it passes or the timeout value is reached.                                   |
-| `resolveFileName` | `resolveNameAsFile` | Custom resolver for the file path used to store snapshots.                                              |
-| `updateDelay`     | `250`               | Delay in ms before repeatable snapshots are created in update mode.                                     |
-
-### JSON Snapshot Options
-
-| Option                             | Default Value | Description                                                                 |
-| ---------------------------------- | ------------- | --------------------------------------------------------------------------- |
-| `includeUndefinedObjectProperties` | `false`       | Serializes `undefined` properties in objects. By default, they are omitted. |
-
-### Text Snapshot Options
-
-| Option          | Default Value | Description                                    |
-| --------------- | ------------- | ---------------------------------------------- |
-| `fileExtension` | `txt`         | File extension used for storing the text file. |

--- a/packages/docs/src/playwright/file-matchers/to-match-json-file.md
+++ b/packages/docs/src/playwright/file-matchers/to-match-json-file.md
@@ -1,0 +1,73 @@
+# toMatchJsonFile
+
+Asserts that a value matches a JSON file snapshot. The value is serialized to JSON and compared to a stored validation file. Supports retries when a callback function is provided as the actual value.
+
+## Usage
+
+### Static Snapshot
+
+```ts
+test("matches page title ultimately", async () => {
+  await page.setContent("<title>Page Title</title>");
+
+  await expect({
+    title: await page.title(),
+  }).toMatchJsonFile();
+});
+```
+
+**Output (`matches_page_title.json`):**
+
+```json
+{
+  "title": "Page Title"
+}
+```
+
+### Repeatable Snapshot
+
+When passing a callback function as actual value, the snapshot will be [retried](/playwright/writing-tests#snapshot-retries) until it matches the stored validation file:
+
+```ts
+test("matches page title eventually", async () => {
+  await page.setContent("<title>Page Title</title>");
+
+  await expect(async () => ({
+    title: await page.title(),
+  })).toMatchJsonFile();
+});
+```
+
+## `undefined` Object Properties
+
+By default, object properties with an `undefined` value are omitted from the snapshot. Set `includeUndefinedObjectProperties` to `true` to include them:
+
+```ts
+test("includes undefined properties", async () => {
+  await expect({ name: "Alice", age: undefined }).toMatchJsonFile({
+    includeUndefinedObjectProperties: true,
+  });
+});
+```
+
+**Output (`includes_undefined_properties.json`):**
+
+```json
+{
+  "name": "Alice",
+  "age": {
+    "$type": "undefined"
+  }
+}
+```
+
+## Options
+
+| Option                             | Default Value                                               | Description                                                                                                                                                                 |
+| ---------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `includeUndefinedObjectProperties` | `false`                                                     | Serializes `undefined` properties in objects. By default, they are omitted.                                                                                                 |
+| `name`                             | `undefined`                                                 | Unique name of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. See [Named Snapshots](/playwright/writing-tests#named-snapshots).     |
+| `normalizers`                      | `[]`                                                        | Custom normalizers to apply before serialization. See [Normalization of Snapshots](/playwright/writing-tests#normalization-of-snapshots).                                   |
+| `timeout`                          | [expect timeout](https://playwright.dev/docs/test-timeouts) | Retries the snapshot until it passes or the timeout is reached. Only applies when a callback is passed. See [Snapshot Retries](/playwright/writing-tests#snapshot-retries). |
+| `updateDelay`                      | `250`                                                       | Delay in ms before a repeatable snapshot is created in update mode. See See [Snapshot Retries](/playwright/writing-tests#snapshot-retries).                                 |
+| `resolveFilePath`                  | `resolveNameAsFile`                                         | Custom resolver for the file path used to store snapshots. See [Named Snapshots](/playwright/writing-tests#named-snapshots).                                                |

--- a/packages/docs/src/playwright/file-matchers/to-match-text-file.md
+++ b/packages/docs/src/playwright/file-matchers/to-match-text-file.md
@@ -1,0 +1,64 @@
+# toMatchTextFile
+
+Asserts that a string value matches a text file snapshot. The string is trimmed and compared to a stored validation file. Supports retries when a callback function is provided as the actual value.
+
+## Usage
+
+### Static Snapshot
+
+```ts
+test("matches page title", async () => {
+  await page.setContent("<title>Page Title</title>");
+
+  await expect(page.title()).toMatchTextFile();
+});
+```
+
+**Output (`matches_page_title.txt`):**
+
+```
+Page Title
+```
+
+### Repeatable Snapshot
+
+When passing a callback function as actual value, the snapshot will be [retried](/playwright/writing-tests#snapshot-retries) until it matches the stored validation file:
+
+```ts
+test("matches page title eventually", async () => {
+  await page.setContent("<title>Page Title</title>");
+
+  await expect(() => page.title()).toMatchTextFile();
+});
+```
+
+## Custom File Extension
+
+Use `fileExtension` to store snapshots with a different file extension:
+
+```ts
+test("matches HTML snapshot", async ({ page }) => {
+  await page.setContent("<main>Hello World</main>");
+
+  await expect(() => page.getByRole("main").innerHTML()).toMatchTextFile({
+    fileExtension: "html",
+  });
+});
+```
+
+**Output (`matches_HTML_snapshot.html`):**
+
+```html
+<main>Hello World</main>
+```
+
+## Options
+
+| Option            | Default Value                                               | Description                                                                                                                                                                 |
+| ----------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fileExtension`   | `txt`                                                       | File extension used for storing the snapshot file.                                                                                                                          |
+| `name`            | `undefined`                                                 | Unique name of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. See [Named Snapshots](/playwright/writing-tests#named-snapshots).     |
+| `normalizers`     | `[]`                                                        | Custom normalizers to apply before serialization. See [Normalization of Snapshots](/playwright/writing-tests#normalization-of-snapshots).                                   |
+| `timeout`         | [expect timeout](https://playwright.dev/docs/test-timeouts) | Retries the snapshot until it passes or the timeout is reached. Only applies when a callback is passed. See [Snapshot Retries](/playwright/writing-tests#snapshot-retries). |
+| `updateDelay`     | `250`                                                       | Delay in ms before a repeatable snapshot is created in update mode. See [Snapshot Retries](/playwright/writing-tests#snapshot-retries).                                     |
+| `resolveFilePath` | `resolveNameAsFile`                                         | Custom resolver for the file path used to store snapshots. See [Named Snapshots](/playwright/writing-tests#named-snapshots).                                                |

--- a/packages/docs/src/playwright/writing-tests.md
+++ b/packages/docs/src/playwright/writing-tests.md
@@ -1,11 +1,13 @@
 # Writing Tests
 
-File snapshot assertions use one of the custom matchers:
+## File Matchers
 
-- `toMatchJsonFile`
-- `toMatchTextFile`
+Each file matcher targets a specific snapshot format:
 
-## JSON File Snapshot
+- [`toMatchJsonFile`](/playwright/file-matchers/to-match-json-file) — serializes the value as a JSON file
+- [`toMatchTextFile`](/playwright/file-matchers/to-match-text-file) — serializes the value as a plain text file
+
+**Example:**
 
 ```ts
 test("value is expected value", async () => {
@@ -19,20 +21,6 @@ test("value is expected value", async () => {
 {
   "value": "expected value"
 }
-```
-
-## Text File Snapshot
-
-```ts
-test("value is expected value", async () => {
-  await expect("expected value").toMatchTextFile();
-});
-```
-
-**Output (`value_is_expected_value.txt`):**
-
-```
-expected value
 ```
 
 ## Normalization of Snapshots
@@ -102,7 +90,7 @@ test("retry snapshot", async ({ page }) => {
 });
 ```
 
-By default, Playwright's Expect timeout (5 s) is used. To define a custom timeout, pass the `timeout` option to the matcher:
+By default, Playwright's [expect timeout](https://playwright.dev/docs/test-timeouts) (5 s) is used. To define a custom timeout, pass the `timeout` option to the matcher:
 
 ```ts
 test("retry snapshot", async ({ page }) => {
@@ -114,7 +102,7 @@ test("retry snapshot", async ({ page }) => {
 
 When creating missing file snapshots, instead of retrying a delay of 250 ms (or `timeout` when lower) is added before performing the snapshot. This avoids flaky snapshots and long-running tests. The same behavior is used when updating snapshots.
 
-The default delay can be overridden by defining `updateDelay` as matcher or file snapshot option.
+The default delay can be overridden by defining `updateDelay` as matcher or configuration option.
 
 ## Using Soft Assertions
 

--- a/packages/docs/src/vitest/configuration.md
+++ b/packages/docs/src/vitest/configuration.md
@@ -1,8 +1,6 @@
 # Configuration
 
-## Matcher Options
-
-Matcher options can be passed when registering the matchers in the setup file:
+Configuration options can be passed when registering the file matchers in the setup file:
 
 ```ts
 registerValidationFileMatchers({
@@ -19,33 +17,3 @@ registerValidationFileMatchers({
 | `outputDir`       | `data/test/output`     | Directory in which file snapshots from test runs are stored.                              |
 | `indentSize`      | `2`                    | Indentation size in spaces used for serializing snapshots.                                |
 | `resolveFileName` | `resolveNameAsFile`    | Custom resolver for the file path used to store snapshots.                                |
-
-## File Snapshot Options
-
-Snapshot options can be passed whenever calling the validation file matcher:
-
-```ts
-expect(value).toMatchJsonFile({
-  name: "snapshot",
-});
-```
-
-### Common Options
-
-| Option            | Default Value       | Description                                                                                             |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `name`            | `undefined`         | Unique `name` of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. |
-| `normalizers`     | `[]`                | Custom normalizers to apply before serialization.                                                       |
-| `resolveFileName` | `resolveNameAsFile` | Custom resolver for the file path used to store snapshots.                                              |
-
-### JSON Snapshot Options
-
-| Option                             | Default Value | Description                                                                 |
-| ---------------------------------- | ------------- | --------------------------------------------------------------------------- |
-| `includeUndefinedObjectProperties` | `false`       | Serializes `undefined` properties in objects. By default, they are omitted. |
-
-### Text Snapshot Options
-
-| Option          | Default Value | Description                                    |
-| --------------- | ------------- | ---------------------------------------------- |
-| `fileExtension` | `txt`         | File extension used for storing the text file. |

--- a/packages/docs/src/vitest/file-matchers/to-match-json-file.md
+++ b/packages/docs/src/vitest/file-matchers/to-match-json-file.md
@@ -1,0 +1,51 @@
+# toMatchJsonFile
+
+Asserts that a value matches a JSON file snapshot. The value is serialized to JSON and compared to a stored validation file.
+
+## Usage
+
+```ts
+test("value is expected value", () => {
+  expect({ value: "expected value" }).toMatchJsonFile();
+});
+```
+
+**Output (`value_is_expected_value.json`):**
+
+```json
+{
+  "value": "expected value"
+}
+```
+
+## `undefined` Object Properties
+
+By default, object properties with an `undefined` value are omitted from the snapshot. Set `includeUndefinedObjectProperties` to `true` to include them:
+
+```ts
+test("includes undefined properties", () => {
+  expect({ name: "Alice", age: undefined }).toMatchJsonFile({
+    includeUndefinedObjectProperties: true,
+  });
+});
+```
+
+**Output (`includes_undefined_properties.json`):**
+
+```json
+{
+  "name": "Alice",
+  "age": {
+    "$type": "undefined"
+  }
+}
+```
+
+## Options
+
+| Option                             | Default Value       | Description                                                                                                                                                         |
+| ---------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `includeUndefinedObjectProperties` | `false`             | Serializes `undefined` properties in objects. By default, they are omitted.                                                                                         |
+| `name`                             | `undefined`         | Unique name of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. See [Named Snapshots](/vitest/writing-tests#named-snapshots). |
+| `normalizers`                      | `[]`                | Custom normalizers to apply before serialization. See [Normalization of Snapshots](/vitest/writing-tests#normalization-of-snapshots).                               |
+| `resolveFilePath`                  | `resolveNameAsFile` | Custom resolver for the file path used to store snapshots.                                                                                                          |

--- a/packages/docs/src/vitest/file-matchers/to-match-text-file.md
+++ b/packages/docs/src/vitest/file-matchers/to-match-text-file.md
@@ -1,0 +1,42 @@
+# toMatchTextFile
+
+Asserts that a string value matches a text file snapshot. The string is trimmed and compared to a stored validation file.
+
+## Usage
+
+```ts
+test("value is expected value", () => {
+  expect("expected value").toMatchTextFile();
+});
+```
+
+**Output (`value_is_expected_value.txt`):**
+
+```
+expected value
+```
+
+## Custom File Extension
+
+Use `fileExtension` to store snapshots with a different file extension:
+
+```ts
+test("html snapshot", () => {
+  expect("<main>Hello World</main>").toMatchTextFile({ fileExtension: "html" });
+});
+```
+
+**Output (`html_snapshot.html`):**
+
+```html
+<main>Hello World</main>
+```
+
+## Options
+
+| Option            | Default Value       | Description                                                                                                                                                         |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fileExtension`   | `txt`               | File extension used for storing the snapshot file.                                                                                                                  |
+| `name`            | `undefined`         | Unique name of the file snapshot. Used to distinguish multiple file snapshots within the same `test`. See [Named Snapshots](/vitest/writing-tests#named-snapshots). |
+| `normalizers`     | `[]`                | Custom normalizers to apply before serialization. See [Normalization of Snapshots](/vitest/writing-tests#normalization-of-snapshots).                               |
+| `resolveFilePath` | `resolveNameAsFile` | Custom resolver for the file path used to store snapshots.                                                                                                          |

--- a/packages/docs/src/vitest/writing-tests.md
+++ b/packages/docs/src/vitest/writing-tests.md
@@ -1,13 +1,13 @@
 # Writing Tests
 
-## Custom Matchers
+## File Matchers
 
-File snapshot assertions use one of the custom matchers:
+Each file matcher targets a specific snapshot format:
 
-- `toMatchJsonFile` - for JSON file snapshots
-- `toMatchTextFile` - for text file snapshots
+- [`toMatchJsonFile`](/vitest/file-matchers/to-match-json-file) — serializes the value as a JSON file
+- [`toMatchTextFile`](/vitest/file-matchers/to-match-text-file) — serializes the value as a plain text file
 
-## JSON File Snapshots
+**Example:**
 
 ```ts
 test("value is expected value", () => {
@@ -21,20 +21,6 @@ test("value is expected value", () => {
 {
   "value": "expected value"
 }
-```
-
-## Text File Snapshots
-
-```ts
-test("value is expected value", () => {
-  expect("expected value").toMatchTextFile();
-});
-```
-
-**Output (`value_is_expected_value.txt`):**
-
-```
-expected value
 ```
 
 ## Multiple Expectations
@@ -65,7 +51,7 @@ test("maps values to string", () => {
 }
 ```
 
-## Normalization
+## Normalization of Snapshots
 
 Normalizers can be used to apply custom normalization, e.g., mask values which are not stable. Custom normalizers are applied before internal normalizers and the snapshot serialization.
 


### PR DESCRIPTION
This PR introduces separate documentation pages for individual file matchers, improving the discoverability of matchers and enabling an isolated documentation of matcher-specific options. The "Writing Tests" page is now used as an entry point and to describe shared concepts.

The section "Element Snapshots" and "ARIA Snapshots" for the Playwright documentation were moved one level upwards to better separate them from the core library.