### PR TITLE
feat(lib-file-snapshots): Add generic type parameter to serializers

### DIFF
--- a/.changeset/metal-experts-remain.md
+++ b/.changeset/metal-experts-remain.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": minor
+---
+
+Enable strict typing of serializer input value

--- a/packages/lib-file-snapshots/src/__tests__/text-serializer.test.ts
+++ b/packages/lib-file-snapshots/src/__tests__/text-serializer.test.ts
@@ -1,7 +1,7 @@
 import { test } from "vitest";
 
 import { TextSerializer } from "../serializers/text-serializer";
-import { testSerializer, testSerializerThrows } from "../utils/test";
+import { testSerializer } from "../utils/test";
 
 test("text", testSerializer(new TextSerializer(), "value"));
 
@@ -24,11 +24,6 @@ test(
     new TextSerializer({ normalizers: [maskNumber, removeComment] }),
     "4711 comment",
   ),
-);
-
-test(
-  "when value is not of type string, throws error",
-  testSerializerThrows(new TextSerializer(), ["value"]),
 );
 
 function maskNumber(value: string): string {

--- a/packages/lib-file-snapshots/src/__tests__/validation-file-matcher.test.ts
+++ b/packages/lib-file-snapshots/src/__tests__/validation-file-matcher.test.ts
@@ -76,7 +76,7 @@ function optionalFileBlock(filePath: string): string {
 }
 
 function persistentSnapshotDirs(): Pick<
-  ValidationFileMatcherConfig,
+  ValidationFileMatcherConfig<unknown>,
   "validationDir" | "outputDir"
 > {
   return {
@@ -87,7 +87,7 @@ function persistentSnapshotDirs(): Pick<
 
 function temporarySnapshotDirs(
   tmpDir: string,
-): Pick<ValidationFileMatcherConfig, "validationDir" | "outputDir"> {
+): Pick<ValidationFileMatcherConfig<unknown>, "validationDir" | "outputDir"> {
   return {
     validationDir: path.join(tmpDir, "validation"),
     outputDir: path.join(tmpDir, "output"),

--- a/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
+++ b/packages/lib-file-snapshots/src/matcher/validation-file-matcher.ts
@@ -18,13 +18,13 @@ interface MatcherFilePaths {
   validationFilePath: string;
 }
 
-export class ValidationFileMatcher {
+export class ValidationFileMatcher<TValue> {
   private readonly updateSnapshots: UpdateSnapshotsType;
-  private readonly serializer: SnapshotSerializer;
+  private readonly serializer: SnapshotSerializer<TValue>;
   private readonly filePaths: MatcherFilePaths;
   private validationFile: string | undefined;
 
-  public constructor(config: ValidationFileMatcherConfig) {
+  public constructor(config: ValidationFileMatcherConfig<TValue>) {
     this.updateSnapshots = config.updateSnapshots ?? "missing";
     this.serializer = config.serializer;
     this.filePaths = this.buildFilePaths(config);
@@ -42,7 +42,7 @@ export class ValidationFileMatcher {
     );
   }
 
-  public matchFileSnapshot(actual: unknown): ValidationFileMatcherResult {
+  public matchFileSnapshot(actual: TValue): ValidationFileMatcherResult {
     const serializedActual = this.serializer.serialize(actual);
     const expected = this.resolveExpected(serializedActual);
 
@@ -53,7 +53,7 @@ export class ValidationFileMatcher {
   }
 
   private buildFilePaths(
-    config: ValidationFileMatcherConfig,
+    config: ValidationFileMatcherConfig<TValue>,
   ): MatcherFilePaths {
     const { validationDir, outputDir, filePath, serializer } = config;
     const filePathWithExtension = `${filePath}.${serializer.fileExtension}`;

--- a/packages/lib-file-snapshots/src/serializers/json-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/json-serializer.ts
@@ -42,7 +42,7 @@ export interface JsonNormalizerContext {
   index?: number;
 }
 
-export class JsonSerializer implements SnapshotSerializer {
+export class JsonSerializer implements SnapshotSerializer<unknown> {
   public readonly fileExtension = "json";
 
   private readonly includeUndefinedObjectProperties: boolean;

--- a/packages/lib-file-snapshots/src/serializers/text-serializer.ts
+++ b/packages/lib-file-snapshots/src/serializers/text-serializer.ts
@@ -1,6 +1,5 @@
 import type { SnapshotSerializer } from "../types/serializer";
 import { addTrailingNewLine } from "../utils/file";
-import { isString } from "../utils/guards";
 
 export interface TextSerializerOptions {
   /**
@@ -18,7 +17,7 @@ export interface TextSerializerOptions {
 
 export type TextNormalizer = (value: string) => string;
 
-export class TextSerializer implements SnapshotSerializer {
+export class TextSerializer implements SnapshotSerializer<string> {
   public readonly fileExtension;
 
   private readonly normalizers: Array<TextNormalizer>;
@@ -28,13 +27,7 @@ export class TextSerializer implements SnapshotSerializer {
     this.fileExtension = options.fileExtension ?? "txt";
   }
 
-  public serialize(value: unknown): string {
-    if (!isString(value)) {
-      throw new Error(
-        `Value of type ${typeof value} cannot be serialized as text. Only strings are supported.`,
-      );
-    }
-
+  public serialize(value: string): string {
     const normalizedValue = this.normalizeValue(value);
     return addTrailingNewLine(normalizedValue);
   }

--- a/packages/lib-file-snapshots/src/types/matcher.ts
+++ b/packages/lib-file-snapshots/src/types/matcher.ts
@@ -1,6 +1,6 @@
 import type { SnapshotSerializer } from "./serializer";
 
-export interface ValidationFileMatcherConfig {
+export interface ValidationFileMatcherConfig<TValue> {
   /**
    * Directory in which golden masters are stored
    */
@@ -21,7 +21,7 @@ export interface ValidationFileMatcherConfig {
   /**
    * The serializer to use for the snapshot
    */
-  serializer: SnapshotSerializer;
+  serializer: SnapshotSerializer<TValue>;
 
   /**
    * Whether to update golden masters with the actual result.

--- a/packages/lib-file-snapshots/src/types/serializer.ts
+++ b/packages/lib-file-snapshots/src/types/serializer.ts
@@ -1,4 +1,4 @@
-export interface SnapshotSerializer {
+export interface SnapshotSerializer<TValue> {
   /**
    * The file extension associated with the serialized value
    */
@@ -11,5 +11,5 @@ export interface SnapshotSerializer {
    * @return {string} The serialized value
    * @throws {Error} Will throw an error if value cannot be serialized.
    */
-  serialize(value: unknown): string;
+  serialize(value: TValue): string;
 }

--- a/packages/lib-file-snapshots/src/utils/test.ts
+++ b/packages/lib-file-snapshots/src/utils/test.ts
@@ -11,9 +11,9 @@ export const SNAPSHOTS_DIR = "__snapshots__";
 
 export type SerializerTestFn = (context: TestContext) => Promise<void>;
 
-export function testSerializer(
-  serializer: SnapshotSerializer,
-  value: unknown,
+export function testSerializer<TValue>(
+  serializer: SnapshotSerializer<TValue>,
+  value: TValue,
 ): SerializerTestFn {
   return async (context): Promise<void> => {
     const { testFileName, testName } = resolveTestContext(context);
@@ -31,21 +31,8 @@ export function testSerializer(
   };
 }
 
-export function testSerializerThrows(
-  serializer: SnapshotSerializer,
-  value: unknown,
-): () => void {
-  return (): void => {
-    expect(() => serializer.serialize(value)).toThrowError();
-  };
-}
-
-export class FailingSerializer implements SnapshotSerializer {
+export class FailingSerializer implements SnapshotSerializer<unknown> {
   public readonly fileExtension = "error";
-
-  public canSerialize(_value: unknown): boolean {
-    return false;
-  }
 
   public serialize(_value: unknown): string {
     throw new Error("Not implemented");

--- a/packages/playwright-file-snapshots/src/matchers/define-expect.ts
+++ b/packages/playwright-file-snapshots/src/matchers/define-expect.ts
@@ -13,6 +13,7 @@ import type {
   PlaywrightMatchTextFileOptions,
   PlaywrightValidationFileMatcherConfig,
   PlaywrightValidationFileMatchers,
+  SnapshotValue,
 } from "./types";
 
 export function defineValidationFileExpect(
@@ -22,7 +23,7 @@ export function defineValidationFileExpect(
 
   async function toMatchJsonFile(
     this: ExpectMatcherState,
-    actual: unknown,
+    actual: SnapshotValue<unknown>,
     options: PlaywrightMatchJsonFileOptions = {},
   ): Promise<MatcherReturnType> {
     const {
@@ -46,7 +47,7 @@ export function defineValidationFileExpect(
 
   async function toMatchTextFile(
     this: ExpectMatcherState,
-    actual: unknown,
+    actual: SnapshotValue<string>,
     options: PlaywrightMatchTextFileOptions = {},
   ): Promise<MatcherReturnType> {
     const { normalizers, fileExtension, ...snapshotOptions } = options;

--- a/packages/playwright-file-snapshots/src/matchers/file-matcher.ts
+++ b/packages/playwright-file-snapshots/src/matchers/file-matcher.ts
@@ -27,22 +27,23 @@ import {
 import type {
   PlaywrightMatchValidationFileOptions,
   PlaywrightValidationFileMatcherConfig,
+  SnapshotValue,
 } from "./types";
 import { MATCHER_STEP_TITLE, parseTestInfo, parseTestStepInfo } from "./utils";
 
 const DEFAULT_UPDATE_DELAY = 250;
 
-interface MatchValidationFileParams {
-  actual: unknown;
+interface MatchValidationFileParams<TValue> {
+  actual: SnapshotValue<TValue>;
   matcherName: string;
-  serializer: SnapshotSerializer;
+  serializer: SnapshotSerializer<TValue>;
   config: PlaywrightValidationFileMatcherConfig;
   options: PlaywrightMatchValidationFileOptions;
   matcherState: ExpectMatcherState;
 }
 
-export async function matchValidationFile(
-  params: MatchValidationFileParams,
+export async function matchValidationFile<TValue>(
+  params: MatchValidationFileParams<TValue>,
 ): Promise<MatcherReturnType> {
   const { matcherName, actual, serializer, config, options, matcherState } =
     params;

--- a/packages/playwright-file-snapshots/src/matchers/snapshot.ts
+++ b/packages/playwright-file-snapshots/src/matchers/snapshot.ts
@@ -2,15 +2,19 @@ import { performance } from "node:perf_hooks";
 
 import { waitForTimer } from "../utils/timer";
 
-interface Snapshot {
-  getValue: () => unknown;
+import type {
+  RepeatableSnapshotValue,
+  SnapshotValue,
+  StaticSnapshotValue,
+} from "./types";
+
+interface Snapshot<TValue> {
+  getValue: () => StaticSnapshotValue<TValue>;
 }
 
-type RepeatableSnapshotValue = () => unknown;
-
-export function createSnapshotInstance(
-  value: unknown,
-): StaticSnapshot | RepeatableSnapshot {
+export function createSnapshotInstance<TValue>(
+  value: SnapshotValue<TValue>,
+): StaticSnapshot<TValue> | RepeatableSnapshot<TValue> {
   if (isFunctionWithParameters(value)) {
     throw new Error(
       "Invalid snapshot value: only functions without parameters are supported.",
@@ -18,46 +22,46 @@ export function createSnapshotInstance(
   }
 
   if (isRepeatableSnapshotValue(value)) {
-    return new RepeatableSnapshot(value);
+    return new RepeatableSnapshot<TValue>(value);
   }
 
-  return new StaticSnapshot(value);
+  return new StaticSnapshot<TValue>(value);
 }
 
 function isFunctionWithParameters(value: unknown): boolean {
   return typeof value === "function" && value.length > 0;
 }
 
-function isRepeatableSnapshotValue(
-  value: unknown,
-): value is RepeatableSnapshotValue {
+function isRepeatableSnapshotValue<TValue>(
+  value: SnapshotValue<TValue>,
+): value is RepeatableSnapshotValue<TValue> {
   return typeof value === "function" && value.length === 0;
 }
 
-export class StaticSnapshot implements Snapshot {
-  private readonly value: unknown;
+export class StaticSnapshot<TValue> implements Snapshot<TValue> {
+  private readonly value: StaticSnapshotValue<TValue>;
 
-  public constructor(value: unknown) {
+  public constructor(value: StaticSnapshotValue<TValue>) {
     this.value = value;
   }
 
-  public getValue(): unknown {
+  public getValue(): StaticSnapshotValue<TValue> {
     return this.value;
   }
 }
 
-export class RepeatableSnapshot implements Snapshot {
+export class RepeatableSnapshot<TValue> implements Snapshot<TValue> {
   private readonly maxRetryInterval = 1000;
   private readonly retryIntervals = [100, 250, 500];
   private readonly startTime = performance.now();
   private snapshotCounter = 0;
-  private readonly snapshotValueFn: RepeatableSnapshotValue;
+  private readonly snapshotValueFn: RepeatableSnapshotValue<TValue>;
 
-  public constructor(snapshotValueFn: RepeatableSnapshotValue) {
+  public constructor(snapshotValueFn: RepeatableSnapshotValue<TValue>) {
     this.snapshotValueFn = snapshotValueFn;
   }
 
-  public async getValue(): Promise<unknown> {
+  public async getValue(): Promise<TValue> {
     const snapshot = await this.snapshotValueFn();
     this.snapshotCounter++;
     return snapshot;

--- a/packages/playwright-file-snapshots/src/matchers/types.ts
+++ b/packages/playwright-file-snapshots/src/matchers/types.ts
@@ -45,19 +45,21 @@ export interface PlaywrightValidationFileMatcherConfig {
   updateDelay?: number;
 }
 
-type ValueOrValueFunction<TValue> =
-  | TValue
-  | Promise<TValue>
-  | (() => TValue)
-  | (() => Promise<TValue>);
+export type SnapshotValue<TValue> =
+  | StaticSnapshotValue<TValue>
+  | RepeatableSnapshotValue<TValue>;
+
+export type StaticSnapshotValue<TValue> = TValue | Promise<TValue>;
+
+export type RepeatableSnapshotValue<TValue> = () => StaticSnapshotValue<TValue>;
 
 export interface PlaywrightValidationFileMatchers {
   toMatchJsonFile: (
-    actual: ValueOrValueFunction<unknown>,
+    actual: SnapshotValue<unknown>,
     options?: PlaywrightMatchJsonFileOptions,
   ) => Promise<MatcherReturnType>;
   toMatchTextFile: (
-    actual: ValueOrValueFunction<string>,
+    actual: SnapshotValue<string>,
     options?: PlaywrightMatchTextFileOptions,
   ) => Promise<MatcherReturnType>;
 }

--- a/packages/vitest-file-snapshots/src/__tests__/matcher-utils.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/matcher-utils.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import {
   parseTestName,
   parseTestPath,
+  parseTextValue,
   parseUpdateSnapshot,
 } from "../matchers/utils";
 
@@ -71,4 +72,12 @@ describe("parseUpdateSnapshot", () => {
   test("when value is unknown, returns 'missing'", () => {
     expect(parseUpdateSnapshot("value")).toBe("missing");
   });
+});
+
+describe("parseTextValue", () => {
+  test("when value is of type string, parse returns value", () =>
+    expect(parseTextValue("value")).toBe("value"));
+
+  test("when value is not of type string, parse throws error", () =>
+    expect(() => parseTextValue(["value"])).toThrow());
 });

--- a/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
+++ b/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
@@ -20,16 +20,16 @@ import {
   readUpdateSnapshot,
 } from "./utils";
 
-interface MatchValidationFileParams {
-  received: unknown;
-  serializer: SnapshotSerializer;
+interface MatchValidationFileParams<TValue> {
+  received: TValue;
+  serializer: SnapshotSerializer<TValue>;
   config: VitestValidationFileMatcherConfig;
   options: VitestMatchValidationFileOptions;
   matcherState: MatcherState;
 }
 
-export function matchValidationFile(
-  params: MatchValidationFileParams,
+export function matchValidationFile<TValue>(
+  params: MatchValidationFileParams<TValue>,
 ): ExpectationResult {
   const { received, serializer, config, options, matcherState } = params;
   const { currentTestName, testPath, equals, isNot } = matcherState;

--- a/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
+++ b/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
@@ -10,6 +10,7 @@ import type {
   VitestValidationFileMatcherConfig,
   VitestValidationFileMatchers,
 } from "./types";
+import { parseTextValue } from "./utils";
 
 export function registerValidationFileMatchers(
   config: VitestValidationFileMatcherConfig = {},
@@ -46,7 +47,7 @@ export function registerValidationFileMatchers(
   ): ExpectationResult {
     const { normalizers, fileExtension, ...snapshotOptions } = options;
     return matchValidationFile({
-      received,
+      received: parseTextValue(received),
       serializer: new TextSerializer({ normalizers, fileExtension }),
       config: snapshotConfig,
       options: snapshotOptions,

--- a/packages/vitest-file-snapshots/src/matchers/utils.ts
+++ b/packages/vitest-file-snapshots/src/matchers/utils.ts
@@ -42,3 +42,13 @@ export function parseUpdateSnapshot(
       return "missing";
   }
 }
+
+export function parseTextValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  throw new Error(
+    `Value of type ${typeof value} cannot be parsed as text. Only strings are supported.`,
+  );
+}


### PR DESCRIPTION
This PR adds a generic type parameter to the `SnapshotSerializer` interface, enabling strict typing of the input value. This avoids parsing the value when only the type is relevant and the testing library supports typed matcher values (Playwright).