### PR TITLE
feat(element-snapshot): Always include `placeholder` in input snapshots

### DIFF
--- a/.changeset/yellow-steaks-pump.md
+++ b/.changeset/yellow-steaks-pump.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Always include `placeholder` attribute in input snapshots

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/input_with_value_and_placeholder.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/input_with_value_and_placeholder.json
@@ -3,7 +3,8 @@
     "role": "textbox",
     "name": "Input",
     "attributes": {
-      "value": "Value"
+      "value": "Value",
+      "placeholder": "Placeholder"
     },
     "children": []
   }

--- a/packages/element-snapshot/src/browser/combobox.ts
+++ b/packages/element-snapshot/src/browser/combobox.ts
@@ -22,14 +22,13 @@ export function snapshotCombobox(
   }
 
   const options = snapshotOptions(element);
-  const value = resolveValue(element);
 
   return {
     role: "combobox",
     name: resolveInputLabel(element),
     attributes: {
-      value,
-      ...snapshotCommonInputAttributes(element, value === undefined),
+      value: resolveValue(element),
+      ...snapshotCommonInputAttributes(element),
     },
     children: [],
     options,

--- a/packages/element-snapshot/src/browser/input.ts
+++ b/packages/element-snapshot/src/browser/input.ts
@@ -43,39 +43,34 @@ function snapshotInputElement(element: HTMLInputElement): InputSnapshot | null {
     return null;
   }
 
-  const value = resolveInputValue(element);
-
   return elementSnapshot({
     role: inputRole,
     name: resolveInputLabel(element),
     attributes: {
-      value,
+      value: resolveInputValue(element),
       checked: resolveChecked(element),
-      ...snapshotCommonInputAttributes(element, value === undefined),
+      ...snapshotCommonInputAttributes(element),
     },
   });
 }
 
 function snapshotTextareaElement(element: HTMLTextAreaElement): InputSnapshot {
-  const value = resolveInputValue(element);
-
   return elementSnapshot({
     role: "textbox",
     name: resolveInputLabel(element),
     attributes: {
-      value,
-      ...snapshotCommonInputAttributes(element, value === undefined),
+      value: resolveInputValue(element),
+      ...snapshotCommonInputAttributes(element),
     },
   });
 }
 
 export function snapshotCommonInputAttributes(
   element: InputElement,
-  isEmpty: boolean,
 ): CommonInputAttributes {
   return {
     ...discribableAttributes(element),
-    placeholder: isEmpty ? resolvePlaceholder(element) : undefined,
+    placeholder: resolvePlaceholder(element),
     ...inputStateAttributes(element),
   };
 }


### PR DESCRIPTION
This PR changes the behavior of snapshots for inputs having a placeholder. Previously, the `placeholder` attribute was only included when the input had no value, mimicking the behavior of inputs in UIs. Since this behavior can be confusing, the `placeholder` attribute is now always included in input snapshots.

Closes #382 