### PR TITLE
feat(element snapshot): Support `disabled` attribute on `option` elements

### DIFF
--- a/.changeset/lemon-boats-fry.md
+++ b/.changeset/lemon-boats-fry.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Support `disabled` attribute on elements with role `option`

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
@@ -16,7 +16,7 @@
     "attributes": {
       "value": [
         "Option 1",
-        "Option 2"
+        "Option 3"
       ]
     },
     "children": [],
@@ -47,14 +47,14 @@
       },
       {
         "role": "option",
-        "name": "Option 2",
+        "name": "Option 3",
         "attributes": {
           "selected": true
         },
         "children": [
           {
             "role": "text",
-            "name": "Option 2"
+            "name": "Option 3"
           }
         ]
       }

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
@@ -41,6 +41,19 @@
             "name": "Option 2"
           }
         ]
+      },
+      {
+        "role": "option",
+        "name": "Option 3",
+        "attributes": {
+          "disabled": true
+        },
+        "children": [
+          {
+            "role": "text",
+            "name": "Option 3"
+          }
+        ]
       }
     ]
   }

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
@@ -39,6 +39,19 @@
                 "name": "Option 2"
               }
             ]
+          },
+          {
+            "role": "option",
+            "name": "Option 3",
+            "attributes": {
+              "disabled": true
+            },
+            "children": [
+              {
+                "role": "text",
+                "name": "Option 3"
+              }
+            ]
           }
         ]
       }
@@ -69,6 +82,19 @@
           {
             "role": "text",
             "name": "Option 2"
+          }
+        ]
+      },
+      {
+        "role": "option",
+        "name": "Option 3",
+        "attributes": {
+          "disabled": true
+        },
+        "children": [
+          {
+            "role": "text",
+            "name": "Option 3"
           }
         ]
       }

--- a/packages/element-snapshot/src/browser/combobox.ts
+++ b/packages/element-snapshot/src/browser/combobox.ts
@@ -1,7 +1,7 @@
 import type { ComboboxSnapshot, OptionSnapshot } from "../types/elements/input";
 import { filterByRole } from "../utils/filter";
 
-import { booleanAttribute, resolveElementReference } from "./attribute";
+import { resolveElementReference } from "./attribute";
 import { snapshotChildren } from "./children";
 import {
   resolveInputLabel,
@@ -9,6 +9,7 @@ import {
   snapshotCommonInputAttributes,
 } from "./input";
 import { resolveAccessibleName } from "./name";
+import { disableableAttributes, selectableAttributes } from "./state";
 import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
 
@@ -107,10 +108,8 @@ export function snapshotOption(
     role: "option",
     name: resolveAccessibleName(element),
     attributes: {
-      selected:
-        element instanceof HTMLOptionElement
-          ? booleanAttribute(element.selected)
-          : booleanAttribute(element.ariaSelected),
+      ...selectableAttributes(element),
+      ...disableableAttributes(element),
     },
     children: snapshotChildren(element),
   };

--- a/packages/element-snapshot/src/browser/state.ts
+++ b/packages/element-snapshot/src/browser/state.ts
@@ -11,7 +11,9 @@ export function disableableAttributes(
   element: SnapshotTargetElement,
 ): DisableableAttributes {
   const supportsHtmlAttribute =
-    isNativeInputElement(element) || element instanceof HTMLButtonElement;
+    isNativeInputElement(element) ||
+    element instanceof HTMLButtonElement ||
+    element instanceof HTMLOptionElement;
   const disabled = booleanAttribute(
     supportsHtmlAttribute ? element.hasAttribute("disabled") : false,
   );
@@ -24,7 +26,14 @@ export function disableableAttributes(
 export function selectableAttributes(
   element: SnapshotTargetElement,
 ): SelectableAttributes {
-  return { selected: booleanAttribute(element.ariaSelected) };
+  const supportsHtmlAttribute = element instanceof HTMLOptionElement;
+  const selected = booleanAttribute(
+    supportsHtmlAttribute ? element.hasAttribute("selected") : false,
+  );
+
+  return {
+    selected: selected ?? booleanAttribute(element.ariaSelected),
+  };
 }
 
 export function inputStateAttributes(

--- a/packages/element-snapshot/src/types/elements/input.ts
+++ b/packages/element-snapshot/src/types/elements/input.ts
@@ -1,6 +1,8 @@
 import type {
+  DisableableAttributes,
   DiscribableAttributes,
   InputStateAttributes,
+  SelectableAttributes,
 } from "../attributes";
 import type { GenericElementSnapshot } from "../snapshot";
 
@@ -46,6 +48,5 @@ export interface OptionSnapshot extends GenericElementSnapshot<
   OptionAttributes
 > {}
 
-interface OptionAttributes {
-  selected?: boolean;
-}
+interface OptionAttributes
+  extends SelectableAttributes, DisableableAttributes {}

--- a/packages/element-snapshot/tests/elements/input-type.spec.ts
+++ b/packages/element-snapshot/tests/elements/input-type.spec.ts
@@ -152,6 +152,7 @@ test("HTML single select", async ({ page }) => {
       <select id="select">
         <option value="option1" selected>Option 1</option>
         <option value="option2">Option 2</option>
+        <option value="option3" disabled>Option 3</option>
       </select>
     `,
   );
@@ -188,6 +189,7 @@ test("input-based combobox", async ({ page }) => {
       <ul id="options" role="listbox">
         <li role="option" aria-selected="true">Option 1</li>
         <li role="option" aria-selected="false">Option 2</li>
+        <li role="option" aria-disabled="true">Option 3</li>
       </ul>
     `,
   );

--- a/packages/element-snapshot/tests/elements/input-type.spec.ts
+++ b/packages/element-snapshot/tests/elements/input-type.spec.ts
@@ -165,7 +165,7 @@ test("HTML multi select", async ({ page }) => {
       <select id="select" multiple>
         <option value="option1" selected>Option 1</option>
         <option value="option2">Option 2</option>
-        <option value="option3" selected>Option 2</option>
+        <option value="option3" selected>Option 3</option>
       </select>
     `,
   );


### PR DESCRIPTION
This PR adds support for snapshotting `disabled` and `aria-disabled` attributes on elements with the role `option`.

Closes #385 