### PR TITLE
fix(element snapshot): Semantic snapshot for `combobox` is missing included options

### DIFF
--- a/.changeset/smooth-planets-enjoy.md
+++ b/.changeset/smooth-planets-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Fix: Semantic snapshot for `combobox` is missing included options when combobox has no attributes

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_button-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_button-based_combobox.json
@@ -3,35 +3,35 @@
     "role": "combobox",
     "name": "Combobox",
     "attributes": {
-      "value": "Button Value"
-    },
-    "children": [],
-    "options": [
-      {
-        "role": "option",
-        "name": "Option 1",
-        "attributes": {
-          "selected": true
+      "value": "Button Value",
+      "options": [
+        {
+          "role": "option",
+          "name": "Option 1",
+          "attributes": {
+            "selected": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 1"
+            }
+          ]
         },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 1"
-          }
-        ]
-      },
-      {
-        "role": "option",
-        "name": "Option 2",
-        "attributes": {},
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 2"
-          }
-        ]
-      }
-    ]
+        {
+          "role": "option",
+          "name": "Option 2",
+          "attributes": {},
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 2"
+            }
+          ]
+        }
+      ]
+    },
+    "children": []
   },
   {
     "role": "listbox",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
@@ -12,35 +12,35 @@
         "role": "combobox",
         "name": "Combobox",
         "attributes": {
-          "value": "Input Value"
-        },
-        "children": [],
-        "options": [
-          {
-            "role": "option",
-            "name": "Option 1",
-            "attributes": {
-              "selected": true
+          "value": "Input Value",
+          "options": [
+            {
+              "role": "option",
+              "name": "Option 1",
+              "attributes": {
+                "selected": true
+              },
+              "children": [
+                {
+                  "role": "text",
+                  "name": "Option 1"
+                }
+              ]
             },
-            "children": [
-              {
-                "role": "text",
-                "name": "Option 1"
-              }
-            ]
-          },
-          {
-            "role": "option",
-            "name": "Option 2",
-            "attributes": {},
-            "children": [
-              {
-                "role": "text",
-                "name": "Option 2"
-              }
-            ]
-          }
-        ]
+            {
+              "role": "option",
+              "name": "Option 2",
+              "attributes": {},
+              "children": [
+                {
+                  "role": "text",
+                  "name": "Option 2"
+                }
+              ]
+            }
+          ]
+        },
+        "children": []
       }
     ]
   },

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
@@ -17,47 +17,47 @@
       "value": [
         "Option 1",
         "Option 3"
+      ],
+      "options": [
+        {
+          "role": "option",
+          "name": "Option 1",
+          "attributes": {
+            "selected": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 1"
+            }
+          ]
+        },
+        {
+          "role": "option",
+          "name": "Option 2",
+          "attributes": {},
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 2"
+            }
+          ]
+        },
+        {
+          "role": "option",
+          "name": "Option 3",
+          "attributes": {
+            "selected": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 3"
+            }
+          ]
+        }
       ]
     },
-    "children": [],
-    "options": [
-      {
-        "role": "option",
-        "name": "Option 1",
-        "attributes": {
-          "selected": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 1"
-          }
-        ]
-      },
-      {
-        "role": "option",
-        "name": "Option 2",
-        "attributes": {},
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 2"
-          }
-        ]
-      },
-      {
-        "role": "option",
-        "name": "Option 3",
-        "attributes": {
-          "selected": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 3"
-          }
-        ]
-      }
-    ]
+    "children": []
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
@@ -14,47 +14,47 @@
     "role": "combobox",
     "name": "Single Select",
     "attributes": {
-      "value": "Option 1"
+      "value": "Option 1",
+      "options": [
+        {
+          "role": "option",
+          "name": "Option 1",
+          "attributes": {
+            "selected": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 1"
+            }
+          ]
+        },
+        {
+          "role": "option",
+          "name": "Option 2",
+          "attributes": {},
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 2"
+            }
+          ]
+        },
+        {
+          "role": "option",
+          "name": "Option 3",
+          "attributes": {
+            "disabled": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 3"
+            }
+          ]
+        }
+      ]
     },
-    "children": [],
-    "options": [
-      {
-        "role": "option",
-        "name": "Option 1",
-        "attributes": {
-          "selected": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 1"
-          }
-        ]
-      },
-      {
-        "role": "option",
-        "name": "Option 2",
-        "attributes": {},
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 2"
-          }
-        ]
-      },
-      {
-        "role": "option",
-        "name": "Option 3",
-        "attributes": {
-          "disabled": true
-        },
-        "children": [
-          {
-            "role": "text",
-            "name": "Option 3"
-          }
-        ]
-      }
-    ]
+    "children": []
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/button-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/button-based_combobox.json
@@ -3,9 +3,9 @@
     "role": "combobox",
     "name": "Combobox",
     "attributes": {
-      "value": "Button Value"
+      "value": "Button Value",
+      "options": []
     },
-    "children": [],
-    "options": []
+    "children": []
   }
 ]

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
@@ -12,48 +12,48 @@
         "role": "combobox",
         "name": "Combobox",
         "attributes": {
-          "value": "Input Value"
+          "value": "Input Value",
+          "options": [
+            {
+              "role": "option",
+              "name": "Option 1",
+              "attributes": {
+                "selected": true
+              },
+              "children": [
+                {
+                  "role": "text",
+                  "name": "Option 1"
+                }
+              ]
+            },
+            {
+              "role": "option",
+              "name": "Option 2",
+              "attributes": {},
+              "children": [
+                {
+                  "role": "text",
+                  "name": "Option 2"
+                }
+              ]
+            },
+            {
+              "role": "option",
+              "name": "Option 3",
+              "attributes": {
+                "disabled": true
+              },
+              "children": [
+                {
+                  "role": "text",
+                  "name": "Option 3"
+                }
+              ]
+            }
+          ]
         },
-        "children": [],
-        "options": [
-          {
-            "role": "option",
-            "name": "Option 1",
-            "attributes": {
-              "selected": true
-            },
-            "children": [
-              {
-                "role": "text",
-                "name": "Option 1"
-              }
-            ]
-          },
-          {
-            "role": "option",
-            "name": "Option 2",
-            "attributes": {},
-            "children": [
-              {
-                "role": "text",
-                "name": "Option 2"
-              }
-            ]
-          },
-          {
-            "role": "option",
-            "name": "Option 3",
-            "attributes": {
-              "disabled": true
-            },
-            "children": [
-              {
-                "role": "text",
-                "name": "Option 3"
-              }
-            ]
-          }
-        ]
+        "children": []
       }
     ]
   },

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
@@ -1,6 +1,19 @@
 [
   {
-    "combobox": "Combobox"
+    "combobox": {
+      "name": "Combobox",
+      "options": [
+        {
+          "option": {
+            "name": "Option 1",
+            "selected": true
+          }
+        },
+        {
+          "option": "Option 2"
+        }
+      ]
+    }
   },
   {
     "listbox": [

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
@@ -1,0 +1,18 @@
+[
+  {
+    "combobox": "Combobox"
+  },
+  {
+    "listbox": [
+      {
+        "option": {
+          "name": "Option 1",
+          "selected": true
+        }
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/src/browser/combobox.ts
+++ b/packages/element-snapshot/src/browser/combobox.ts
@@ -30,9 +30,9 @@ export function snapshotCombobox(
     attributes: {
       value: resolveValue(element),
       ...snapshotCommonInputAttributes(element),
+      options,
     },
     children: [],
-    options,
   };
 }
 

--- a/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
+++ b/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
@@ -106,10 +106,12 @@ export class SemanticSnapshotTransformer {
 
   private normalizeElementSnapshot(
     snapshot: ElementSnapshot,
+    excludeAttributes: Array<string> = [],
   ): NormalizedElementSnapshot {
     const normalizedName = snapshot.name ?? "";
-    const sparseAttributes = this.removeUndefinedProperties(
+    const filteredAttributes = this.filterAttributes(
       snapshot.attributes as Record<string, unknown>,
+      excludeAttributes,
     );
     const transformedChildren = this.transformSnapshots(snapshot.children);
     const nameEqualsChildren =
@@ -119,15 +121,17 @@ export class SemanticSnapshotTransformer {
     return {
       role: snapshot.role,
       name: normalizedName,
-      attributes: sparseAttributes,
+      attributes: filteredAttributes,
       children: nameEqualsChildren ? [] : transformedChildren,
     };
   }
 
   private simplifyComboboxSnapshot(snapshot: ComboboxSnapshot): unknown {
-    const { role, name, attributes } = this.normalizeElementSnapshot(snapshot);
-    const transformedOptions = snapshot.options.map((optionSnapshot) =>
-      this.simplifyElementSnapshot(optionSnapshot),
+    const { role, name, attributes } = this.normalizeElementSnapshot(snapshot, [
+      "options",
+    ]);
+    const transformedOptions = snapshot.attributes.options.map(
+      (optionSnapshot) => this.simplifyElementSnapshot(optionSnapshot),
     );
 
     return this.transformedSnapshot(role, {
@@ -164,18 +168,21 @@ export class SemanticSnapshotTransformer {
     );
   }
 
-  private removeUndefinedProperties(
+  private filterAttributes(
     attributes: Record<string, unknown>,
+    exclude: Array<string>,
   ): Record<string, unknown> {
-    const sparseAttributes: Record<string, unknown> = {};
+    const filteredAttributes: Record<string, unknown> = {};
 
     Object.entries(attributes).forEach(([key, value]) => {
-      if (value !== undefined) {
-        sparseAttributes[key] = value;
+      if (value === undefined && !exclude.includes(key)) {
+        return;
       }
+
+      filteredAttributes[key] = value;
     });
 
-    return sparseAttributes;
+    return filteredAttributes;
   }
 
   private transformedSnapshot(role: ElementRole, content: unknown): unknown {

--- a/packages/element-snapshot/src/types/elements/input.ts
+++ b/packages/element-snapshot/src/types/elements/input.ts
@@ -35,12 +35,11 @@ export interface CommonInputAttributes
 export interface ComboboxSnapshot extends GenericElementSnapshot<
   "combobox",
   ComboboxAttributes
-> {
-  options: Array<OptionSnapshot>;
-}
+> {}
 
 interface ComboboxAttributes extends CommonInputAttributes {
   value?: string | Array<string>;
+  options: Array<OptionSnapshot>;
 }
 
 export interface OptionSnapshot extends GenericElementSnapshot<

--- a/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
+++ b/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
@@ -64,3 +64,24 @@ test("excludes empty options", async ({ page }) => {
 
   await matchSnapshot({ includeComboboxOptions: true });
 });
+
+test("include options minimal case", async ({ page }) => {
+  const matchSnapshot = await setupSemanticSnapshotTest(
+    page,
+    html`
+      <input
+        type="text"
+        role="combobox"
+        aria-label="Combobox"
+        aria-controls="options"
+        aria-expanded="false"
+      />
+      <ul id="options" role="listbox">
+        <li role="option" aria-selected="true">Option 1</li>
+        <li role="option" aria-selected="false">Option 2</li>
+      </ul>
+    `,
+  );
+
+  await matchSnapshot({ includeComboboxOptions: true });
+});


### PR DESCRIPTION
This PR fixes a bug where options of a `combobox` were not included in the semantic snapshot even though `includeComboboxOptions: true` was set.

The reason was that the snapshot was falsely simplified, because it had no attributes and the options were not treated as an attributes. Moving `options` to `ComboboxOptions` fixes this problem and allows to keep the generic transformations in `SemanticSnapshotTransformer`.