### PR TITLE
refactor(vitest-file-snapshots): Read update state from public API

### DIFF
--- a/.changeset/some-masks-shop.md
+++ b/.changeset/some-masks-shop.md
@@ -1,0 +1,5 @@
+---
+"@cronn/vitest-file-snapshots": minor
+---
+
+Read snapshot update state from public API (requires Vitest v4.1.4 or higher)

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -78,6 +78,6 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "vitest": "^3.2 || ^4"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/vitest-file-snapshots/src/__tests__/matcher-utils.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/matcher-utils.test.ts
@@ -2,9 +2,10 @@ import path from "node:path";
 import { describe, expect, test } from "vitest";
 
 import {
+  parseSnapshotState,
+  parseSnapshotUpdateState,
   parseTestName,
   parseTestPath,
-  parseUpdateSnapshot,
 } from "../matchers/utils";
 
 describe("parseTestName", () => {
@@ -56,19 +57,23 @@ describe("parseTestPath", () => {
   });
 });
 
-describe("parseUpdateSnapshot", () => {
-  test.each(["all", "none"])(
+describe("parseSnapshotState", () => {
+  test("returns parsed snapshot state", () => {
+    expect(parseSnapshotState({ snapshotUpdateState: "new" })).toStrictEqual({
+      updateSnapshots: "missing",
+    });
+  });
+});
+
+describe("parseSnapshotUpdateState", () => {
+  test.each(["all", "none"] as const)(
     "when value is '%s', returns original value",
     (value) => {
-      expect(parseUpdateSnapshot(value)).toBe(value);
+      expect(parseSnapshotUpdateState(value)).toBe(value);
     },
   );
 
   test("when value is 'new', returns 'missing'", () => {
-    expect(parseUpdateSnapshot("new")).toBe("missing");
-  });
-
-  test("when value is unknown, returns 'missing'", () => {
-    expect(parseUpdateSnapshot("value")).toBe("missing");
+    expect(parseSnapshotUpdateState("new")).toBe("missing");
   });
 });

--- a/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
+++ b/packages/vitest-file-snapshots/src/matchers/file-matcher.ts
@@ -13,12 +13,7 @@ import type {
   VitestMatchValidationFileOptions,
   VitestValidationFileMatcherConfig,
 } from "./types";
-import {
-  parseTestName,
-  parseTestPath,
-  parseUpdateSnapshot,
-  readUpdateSnapshot,
-} from "./utils";
+import { parseSnapshotState, parseTestName, parseTestPath } from "./utils";
 
 interface MatchValidationFileParams<TValue> {
   received: TValue;
@@ -60,7 +55,7 @@ export function matchValidationFile<TValue>(
     titlePath: parseTestName(currentTestName),
     name,
   });
-  const updateSnapshots = parseUpdateSnapshot(readUpdateSnapshot());
+  const { updateSnapshots } = parseSnapshotState(matcherState.snapshotState);
   const matcherResult = new ValidationFileMatcher({
     validationDir,
     outputDir,

--- a/packages/vitest-file-snapshots/src/matchers/utils.ts
+++ b/packages/vitest-file-snapshots/src/matchers/utils.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { expect } from "vitest";
+import type { SnapshotUpdateState } from "vitest";
+import { type MatcherState } from "vitest";
 
 import type { UpdateSnapshotsType } from "@cronn/lib-file-snapshots";
 
@@ -20,20 +21,26 @@ export function parseTestPath(testPath: string, testDir: string): string {
     .replace(TEST_EXTENSION_REGEXP, "");
 }
 
-export function readUpdateSnapshot(): unknown {
-  const snapshotState = expect.getState().snapshotState as object;
-
-  if ("_updateSnapshot" in snapshotState) {
-    return snapshotState._updateSnapshot;
-  }
-
-  return undefined;
+export interface ParsedMatcherState {
+  updateSnapshots: UpdateSnapshotsType;
 }
 
-export function parseUpdateSnapshot(
-  updateSnapshot: unknown,
+type SnapshotState = Pick<MatcherState["snapshotState"], "snapshotUpdateState">;
+
+export function parseSnapshotState(
+  snapshotState: SnapshotState,
+): ParsedMatcherState {
+  return {
+    updateSnapshots: parseSnapshotUpdateState(
+      snapshotState.snapshotUpdateState,
+    ),
+  };
+}
+
+export function parseSnapshotUpdateState(
+  snapshotUpdateState: SnapshotUpdateState,
 ): UpdateSnapshotsType {
-  switch (updateSnapshot) {
+  switch (snapshotUpdateState) {
     case "all":
       return "all";
     case "none":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,11 +29,11 @@ catalogs:
       specifier: 7.0.0-dev.20260406.1
       version: 7.0.0-dev.20260406.1
     '@vitest/coverage-v8':
-      specifier: 4.1.2
-      version: 4.1.2
+      specifier: 4.1.4
+      version: 4.1.4
     '@vitest/expect':
-      specifier: 4.1.2
-      version: 4.1.2
+      specifier: 4.1.4
+      version: 4.1.4
     eslint:
       specifier: 10.2.0
       version: 10.2.0
@@ -71,8 +71,8 @@ catalogs:
       specifier: 1.6.4
       version: 1.6.4
     vitest:
-      specifier: 4.1.2
-      version: 4.1.2
+      specifier: 4.1.4
+      version: 4.1.4
     yaml:
       specifier: 2.8.3
       version: 2.8.3
@@ -148,7 +148,7 @@ importers:
         version: 7.0.0-dev.20260406.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: 'catalog:'
         version: 10.2.0(jiti@2.5.1)
@@ -175,7 +175,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/docs:
     devDependencies:
@@ -248,7 +248,7 @@ importers:
         version: 7.0.0-dev.20260406.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: 'catalog:'
         version: 10.2.0(jiti@2.5.1)
@@ -275,7 +275,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/lib-file-snapshots:
     devDependencies:
@@ -296,7 +296,7 @@ importers:
         version: 7.0.0-dev.20260406.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: 'catalog:'
         version: 10.2.0(jiti@2.5.1)
@@ -326,7 +326,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/meta-updater:
     devDependencies:
@@ -393,7 +393,7 @@ importers:
         version: 7.0.0-dev.20260406.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: 'catalog:'
         version: 10.2.0(jiti@2.5.1)
@@ -420,7 +420,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/shared-configs:
     devDependencies:
@@ -456,7 +456,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/test-utils:
     devDependencies:
@@ -523,10 +523,10 @@ importers:
         version: 7.0.0-dev.20260406.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       '@vitest/expect':
         specifier: 'catalog:'
-        version: 4.1.2
+        version: 4.1.4
       eslint:
         specifier: 'catalog:'
         version: 10.2.0(jiti@2.5.1)
@@ -556,7 +556,7 @@ importers:
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
 packages:
 
@@ -1983,20 +1983,20 @@ packages:
       vite: '>=7.3.2'
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=7.3.2'
@@ -2006,20 +2006,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@vue/compiler-core@3.5.29':
     resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
@@ -4245,18 +4245,20 @@ packages:
       postcss:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': <25
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
       vite: '>=7.3.2'
@@ -4272,6 +4274,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -6290,10 +6296,10 @@ snapshots:
       vite: 8.0.4(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.5.1)(yaml@2.8.3)
       vue: 3.5.29(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2)':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -6302,46 +6308,46 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(vite@8.0.4)
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.4)':
+  '@vitest/mocker@4.1.4(vite@8.0.4)':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.4(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.5.1)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.4': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -8514,15 +8520,15 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.2(@types/node@24.12.0)(vite@8.0.4):
+  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.4):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.4)
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.4)
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -8538,6 +8544,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ catalog:
   "@trivago/prettier-plugin-sort-imports": 6.0.2
   "@typescript/native-preview": 7.0.0-dev.20260406.1
   "@types/node": 24.12.2
-  "@vitest/coverage-v8": 4.1.2
-  "@vitest/expect": 4.1.2
+  "@vitest/coverage-v8": 4.1.4
+  "@vitest/expect": 4.1.4
   "eslint": 10.2.0
   "eslint-config-prettier": 10.1.8
   "eslint-plugin-check-file": 3.3.1
@@ -24,7 +24,7 @@ catalog:
   "turbo": 2.9.4
   "typescript-eslint": 8.58.0
   "vitepress": 1.6.4
-  "vitest": 4.1.2
+  "vitest": 4.1.4
   "yaml": 2.8.3
 
 overrides:


### PR DESCRIPTION
This PR changes `vitest-file-snapshots` to derive the update mode from the Vitest snapshot state, which is included in the public API since Vitest v4.1.4. Previously, an internal API was used which was not typed and can easily break in the future.