### PR TITLE
ci: Add clean script to all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This monorepo uses [Turborepo](https://turborepo.com/) as build system.
 | `pnpm turbo fix`   | Applies automatic fixes, including linting and formatting                         |
 | `pnpm turbo build` | Runs the build                                                                    |
 | `pnpm turbo ci`    | Runs all tasks required for CI, including checks and builds                       |
+| `pnpm turbo clean` | Removes all build outputs and caches                                              |
 
 To run tasks for a specific package only, use [filters](https://turborepo.com/docs/crafting-your-repository/running-tasks#using-filters):
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "format:fix": "prettier . --write --list-different",
     "prepublishOnly": "pnpm turbo run ci",
     "version": "pnpm changeset version && pnpm turbo run format:fix",
-    "release": "pnpm turbo run build && pnpm changeset publish"
+    "release": "pnpm turbo run build && pnpm changeset publish",
+    "clean": "rimraf .turbo"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",
@@ -40,6 +41,7 @@
     "@pnpm/meta-updater": "catalog:",
     "@trivago/prettier-plugin-sort-imports": "catalog:",
     "prettier": "catalog:",
+    "rimraf": "catalog:",
     "turbo": "catalog:"
   }
 }

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -37,7 +37,8 @@
     "test:integration": "playwright test",
     "playwright:install": "playwright install chromium",
     "compile": "tsgo",
-    "build": "tsdown"
+    "build": "tsdown",
+    "clean": "rimraf .turbo dist playwright-report test-results coverage"
   },
   "type": "module",
   "exports": {
@@ -69,6 +70,7 @@
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -32,7 +32,8 @@
     "compile": "tsgo",
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",
-    "docs:preview": "vitepress preview"
+    "docs:preview": "vitepress preview",
+    "clean": "rimraf .turbo .vitepress/cache .vitepress/dist"
   },
   "devDependencies": {
     "@cronn/shared-configs": "workspace:*",
@@ -43,6 +44,7 @@
     "eslint-plugin-check-file": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
+    "rimraf": "catalog:",
     "typescript-eslint": "catalog:",
     "vitepress": "catalog:"
   }

--- a/packages/element-snapshot/package.json
+++ b/packages/element-snapshot/package.json
@@ -37,7 +37,8 @@
     "test:integration": "playwright test",
     "playwright:install": "playwright install chromium",
     "compile": "tsgo",
-    "build": "tsdown"
+    "build": "tsdown",
+    "clean": "rimraf .turbo dist playwright-report test-results coverage"
   },
   "type": "module",
   "exports": {
@@ -71,6 +72,7 @@
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -38,7 +38,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "compile": "tsgo",
-    "build": "tsdown"
+    "build": "tsdown",
+    "clean": "rimraf .turbo dist coverage"
   },
   "type": "module",
   "exports": {
@@ -65,6 +66,7 @@
     "markdown-table": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/packages/meta-updater/package.json
+++ b/packages/meta-updater/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "lint:check": "eslint src/ --max-warnings=0",
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
-    "compile": "tsgo"
+    "compile": "tsgo",
+    "clean": "rimraf .turbo"
   },
   "type": "module",
   "exports": {
@@ -48,6 +49,7 @@
     "eslint-plugin-check-file": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
+    "rimraf": "catalog:",
     "typescript-eslint": "catalog:"
   }
 }

--- a/packages/meta-updater/src/update-package-json.ts
+++ b/packages/meta-updater/src/update-package-json.ts
@@ -72,6 +72,8 @@ interface PackageContext {
   needsEslint: boolean;
   needsTsdown: boolean;
   needsTypeScript: boolean;
+  needsPlaywright: boolean;
+  needsVitest: boolean;
 }
 
 function resolvePackageContext(
@@ -91,6 +93,10 @@ function resolvePackageContext(
     needsEslint: fs.existsSync(path.resolve(absoluteDir, "eslint.config.ts")),
     needsTsdown: fs.existsSync(path.resolve(absoluteDir, "tsdown.config.ts")),
     needsTypeScript: fs.existsSync(path.resolve(absoluteDir, "tsconfig.json")),
+    needsPlaywright: fs.existsSync(
+      path.resolve(absoluteDir, "playwright.config.ts"),
+    ),
+    needsVitest: fs.existsSync(path.resolve(absoluteDir, "vitest.config.ts")),
   };
 }
 
@@ -113,6 +119,7 @@ function updateScripts(scripts: Scripts, context: PackageContext): Scripts {
     ),
     ...when(context.needsTypeScript, defineCompileScript()),
     ...when(context.needsTsdown, updateBuildScript(scripts)),
+    ...updateCleanScript(scripts, context),
   };
 }
 
@@ -148,6 +155,29 @@ function updateBuildScript(scripts: Scripts): Scripts | undefined {
   return updateScript("build", "tsdown", scripts);
 }
 
+function updateCleanScript(
+  scripts: Scripts,
+  context: PackageContext,
+): Scripts | undefined {
+  const outputDirs = [".turbo"];
+
+  if (context.needsTsdown) {
+    outputDirs.push("dist");
+  }
+
+  if (context.needsPlaywright) {
+    outputDirs.push("playwright-report", "test-results");
+  }
+
+  if (context.needsVitest) {
+    outputDirs.push("coverage");
+  }
+
+  const collectedOutputDirs = outputDirs.join(" ");
+
+  return updateScript("clean", `rimraf ${collectedOutputDirs}`, scripts);
+}
+
 function updateScript(
   name: string,
   defaultValue: string,
@@ -178,6 +208,7 @@ function updateDevDependencies(
       "eslint-plugin-unused-imports": "catalog:",
     }),
     prettier: "catalog:",
+    rimraf: "catalog:",
     ...when(context.needsTsdown, { publint: "catalog:", tsdown: "catalog:" }),
     ...when(context.needsEslint, { "typescript-eslint": "catalog:" }),
   };

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -44,7 +44,8 @@
     "test:integration:update-none": "playwright test --grep @update-none --update-snapshots none",
     "playwright:install": "playwright install chromium",
     "compile": "tsgo",
-    "build": "tsdown"
+    "build": "tsdown",
+    "clean": "rimraf .turbo dist playwright-report test-results coverage"
   },
   "type": "module",
   "exports": {
@@ -75,6 +76,7 @@
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "lint:check": "eslint src/ --max-warnings=0",
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
-    "compile": "tsgo"
+    "compile": "tsgo",
+    "clean": "rimraf .turbo"
   },
   "type": "module",
   "exports": {
@@ -60,6 +61,7 @@
     "eslint-plugin-check-file": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -31,7 +31,8 @@
     "lint:check": "eslint src/ --max-warnings=0",
     "lint:fix": "eslint src/ --max-warnings=0 --fix",
     "compile": "tsgo",
-    "build": "tsdown"
+    "build": "tsdown",
+    "clean": "rimraf .turbo dist"
   },
   "type": "module",
   "exports": {
@@ -52,6 +53,7 @@
     "eslint-plugin-unused-imports": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:"
   }

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -42,7 +42,8 @@
     "test:update-none": "vitest run --tags-filter=update-none --update none",
     "test:coverage": "vitest run --tags-filter=!update-* --coverage",
     "compile": "tsgo",
-    "build": "tsdown && node scripts/fix-declaration-file.ts"
+    "build": "tsdown && node scripts/fix-declaration-file.ts",
+    "clean": "rimraf .turbo dist coverage"
   },
   "type": "module",
   "exports": {
@@ -73,6 +74,7 @@
     "package-directory": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
+    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ catalogs:
     publint:
       specifier: 0.3.18
       version: 0.3.18
+    rimraf:
+      specifier: 6.1.3
+      version: 6.1.3
     tsdown:
       specifier: 0.21.7
       version: 0.21.7
@@ -112,6 +115,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       turbo:
         specifier: 'catalog:'
         version: 2.9.4
@@ -167,6 +173,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -203,6 +212,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
@@ -267,6 +279,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -318,6 +333,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -360,6 +378,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
@@ -412,6 +433,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -448,6 +472,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -493,6 +520,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -548,6 +578,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.21.7(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260406.1)(publint@0.3.18)(typescript@5.9.3)
@@ -3486,6 +3519,9 @@ packages:
     resolution: {integrity: sha512-qJSu5Mo6tHmRxCy2KCYYKYgcfBdUpy9dwReaZD/xwf608AUk/MoRtIOWzgDtUeGeC7n/55yC3MI1Q+MbSoektw==}
     engines: {node: '>=18'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -3733,6 +3769,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rolldown-plugin-dts@0.23.2:
@@ -7788,6 +7829,8 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -7998,6 +8041,11 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 13.0.0
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.0
+      package-json-from-dist: 1.0.1
 
   rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260406.1)(rolldown@1.0.0-rc.12)(typescript@5.9.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   "package-directory": 8.2.0
   "prettier": 3.8.1
   "publint": 0.3.18
+  "rimraf": 6.1.3
   "tsdown": 0.21.7
   "turbo": 2.9.4
   "typescript-eslint": 8.58.0

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,9 @@
       "outputs": ["dist/**"],
       "outputLogs": "new-only"
     },
+    "clean": {
+      "outputLogs": "new-only"
+    },
     "ci": {
       "dependsOn": ["^ci", "check", "build"]
     }


### PR DESCRIPTION
Adds `clean` script to remove build outputs and caches.

Closes #374 