### PR TITLE
fix(element-snapshot): Semantic snapshot does not simplify combobox with just name

### DIFF
--- a/.changeset/silent-parks-beg.md
+++ b/.changeset/silent-parks-beg.md
@@ -1,0 +1,5 @@
+---
+"@cronn/lib-file-snapshots": patch
+---
+
+Fix: Move `markdown-table` from `devDependencies` to `dependencies`

--- a/.changeset/tough-shirts-invite.md
+++ b/.changeset/tough-shirts-invite.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Fix: Semantic snapshot does not simplify `combobox` with just name

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
@@ -1,8 +1,6 @@
 [
   {
-    "combobox": {
-      "name": "Combobox"
-    }
+    "combobox": "Combobox"
   },
   {
     "listbox": [

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
@@ -1,0 +1,20 @@
+[
+  {
+    "combobox": {
+      "name": "Combobox"
+    }
+  },
+  {
+    "listbox": [
+      {
+        "option": {
+          "name": "Option 1",
+          "selected": true
+        }
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
+++ b/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
@@ -1,4 +1,3 @@
-import type { ComboboxSnapshot } from "../types/elements/input";
 import type { TextSnapshot } from "../types/elements/text";
 import type { ElementRole } from "../types/role";
 import type { ElementSnapshot, NodeSnapshot } from "../types/snapshot";
@@ -92,10 +91,6 @@ export class SemanticSnapshotTransformer {
       );
     }
 
-    if (snapshot.role === "combobox") {
-      return this.simplifyComboboxSnapshot(snapshot);
-    }
-
     const { role, name, attributes, children } = normalizedSnapshot;
     return this.transformedSnapshot(role, {
       name: name.length === 0 ? undefined : name,
@@ -106,13 +101,9 @@ export class SemanticSnapshotTransformer {
 
   private normalizeElementSnapshot(
     snapshot: ElementSnapshot,
-    excludeAttributes: Array<string> = [],
   ): NormalizedElementSnapshot {
     const normalizedName = snapshot.name ?? "";
-    const filteredAttributes = this.filterAttributes(
-      snapshot.attributes as Record<string, unknown>,
-      excludeAttributes,
-    );
+    const transformedAttributes = this.transformAttributes(snapshot);
     const transformedChildren = this.transformSnapshots(snapshot.children);
     const nameEqualsChildren =
       transformedChildren.length === 1 &&
@@ -121,27 +112,9 @@ export class SemanticSnapshotTransformer {
     return {
       role: snapshot.role,
       name: normalizedName,
-      attributes: filteredAttributes,
+      attributes: transformedAttributes,
       children: nameEqualsChildren ? [] : transformedChildren,
     };
-  }
-
-  private simplifyComboboxSnapshot(snapshot: ComboboxSnapshot): unknown {
-    const { role, name, attributes } = this.normalizeElementSnapshot(snapshot, [
-      "options",
-    ]);
-    const transformedOptions = snapshot.attributes.options.map(
-      (optionSnapshot) => this.simplifyElementSnapshot(optionSnapshot),
-    );
-
-    return this.transformedSnapshot(role, {
-      name,
-      ...attributes,
-      options:
-        this.includeComboboxOptions && transformedOptions.length > 0
-          ? transformedOptions
-          : undefined,
-    });
   }
 
   private isEmpty(snapshot: NormalizedElementSnapshot): boolean {
@@ -168,21 +141,48 @@ export class SemanticSnapshotTransformer {
     );
   }
 
-  private filterAttributes(
-    attributes: Record<string, unknown>,
-    exclude: Array<string>,
+  private transformAttributes(
+    snapshot: ElementSnapshot,
   ): Record<string, unknown> {
+    const { attributes } = snapshot;
     const filteredAttributes: Record<string, unknown> = {};
+    const attributeNames = Object.keys(attributes) as Array<
+      keyof typeof attributes
+    >;
 
-    Object.entries(attributes).forEach(([key, value]) => {
-      if (value === undefined && !exclude.includes(key)) {
+    attributeNames.forEach((attributeName) => {
+      const transformedAttribute = this.transformAttribute(
+        attributeName,
+        snapshot,
+      );
+
+      if (transformedAttribute === undefined) {
         return;
       }
 
-      filteredAttributes[key] = value;
+      filteredAttributes[attributeName] = transformedAttribute;
     });
 
     return filteredAttributes;
+  }
+
+  private transformAttribute(
+    name: keyof ElementSnapshot["attributes"],
+    snapshot: ElementSnapshot,
+  ): unknown {
+    const { role, attributes } = snapshot;
+
+    if (role === "combobox" && name === "options") {
+      const transformedOptions = attributes.options.map((optionSnapshot) =>
+        this.simplifyElementSnapshot(optionSnapshot),
+      );
+
+      return this.includeComboboxOptions && transformedOptions.length > 0
+        ? transformedOptions
+        : undefined;
+    }
+
+    return attributes[name];
   }
 
   private transformedSnapshot(role: ElementRole, content: unknown): unknown {

--- a/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
+++ b/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
@@ -65,6 +65,27 @@ test("excludes empty options", async ({ page }) => {
   await matchSnapshot({ includeComboboxOptions: true });
 });
 
+test("exclude options minimal case", async ({ page }) => {
+  const matchSnapshot = await setupSemanticSnapshotTest(
+    page,
+    html`
+      <input
+        type="text"
+        role="combobox"
+        aria-label="Combobox"
+        aria-controls="options"
+        aria-expanded="false"
+      />
+      <ul id="options" role="listbox">
+        <li role="option" aria-selected="true">Option 1</li>
+        <li role="option" aria-selected="false">Option 2</li>
+      </ul>
+    `,
+  );
+
+  await matchSnapshot();
+});
+
 test("include options minimal case", async ({ page }) => {
   const matchSnapshot = await setupSemanticSnapshotTest(
     page,

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -52,6 +52,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "markdown-table": "catalog:"
+  },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
     "@cronn/shared-configs": "workspace:*",
@@ -63,7 +66,6 @@
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-check-file": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "markdown-table": "catalog:",
     "prettier": "catalog:",
     "publint": "catalog:",
     "rimraf": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,10 @@ importers:
         version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.4)
 
   packages/lib-file-snapshots:
+    dependencies:
+      markdown-table:
+        specifier: 'catalog:'
+        version: 3.0.4
     devDependencies:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
@@ -320,9 +324,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1)(eslint@10.2.0)
-      markdown-table:
-        specifier: 'catalog:'
-        version: 3.0.4
       prettier:
         specifier: 'catalog:'
         version: 3.8.2


### PR DESCRIPTION
This PR fixes a regression where a `combobox` snapshot with just a `name` was not simplified in a semantic snapshot, because the `options` are now also part of the `attributes` and always defined.

In addition, `markdown-table` is now a `dependency` instead of `devDependency` for `lib-file-snapshots`.