### PR TITLE
ci: Simplify CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ env:
 jobs:
   check:
     name: Run CI checks
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, windows-2025]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -39,20 +36,20 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: vitest-reports-${{ matrix.os }}
+          name: vitest-reports-ubuntu
           path: packages/*/coverage/
           retention-days: 3
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-reports-${{ matrix.os }}
+          name: playwright-reports-ubuntu
           path: packages/*/playwright-report/
           retention-days: 3
 
-  build-docs:
-    name: Build documentation
-    runs-on: ubuntu-24.04
+  test-windows:
+    name: Run tests on Windows
+    runs-on: windows-2025
 
     steps:
       - name: Checkout repository
@@ -70,5 +67,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run docs:build
-        run: pnpm turbo docs:build
+      - name: Run tests
+        run: pnpm turbo run test
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: vitest-reports-windows
+          path: packages/*/coverage/
+          retention-days: 3
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-reports-windows
+          path: packages/*/playwright-report/
+          retention-days: 3

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -6,8 +6,8 @@ Published at [cronn.github.io/file-snapshots](https://cronn.github.io/file-snaps
 
 ## Common Tasks
 
-| Command                   | Description              |
-| ------------------------- | ------------------------ |
-| `pnpm turbo docs:dev`     | Start development server |
-| `pnpm turbo docs:build`   | Build for production     |
-| `pnpm turbo docs:preview` | Preview production build |
+| Command              | Description              |
+| -------------------- | ------------------------ |
+| `pnpm turbo dev`     | Start development server |
+| `pnpm turbo build`   | Build for production     |
+| `pnpm turbo preview` | Preview production build |

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -30,9 +30,9 @@
     "lint:check": "eslint .vitepress/config.ts --max-warnings=0",
     "lint:fix": "eslint .vitepress/config.ts --max-warnings=0 --fix",
     "compile": "tsgo",
-    "docs:dev": "vitepress dev",
-    "docs:build": "vitepress build",
-    "docs:preview": "vitepress preview",
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview",
     "clean": "rimraf .turbo .vitepress/cache .vitepress/dist"
   },
   "devDependencies": {

--- a/packages/docs/turbo.json
+++ b/packages/docs/turbo.json
@@ -2,19 +2,18 @@
   "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
-    "docs:dev": {
+    "dev": {
       "persistent": true,
       "dependsOn": ["compile"],
       "outputs": [".vitepress/cache/**"],
       "outputLogs": "new-only"
     },
-    "docs:build": {
-      "dependsOn": ["compile"],
-      "outputs": [".vitepress/dist/**"],
-      "outputLogs": "new-only"
+    "build": {
+      "outputs": [".vitepress/dist/**"]
     },
-    "docs:preview": {
-      "dependsOn": ["docs:build"],
+    "preview": {
+      "persistent": true,
+      "dependsOn": ["build"],
       "outputLogs": "new-only"
     }
   }


### PR DESCRIPTION
Since running all CI checks on Windows is sometimes flaky, the CI workflow was changed as following:

- The `build` for the docs package is now part of the standard `ci` task
- All CI checks are run on Linux, because they run fast and reliable on Linux
- Only the tests are additional run on Windows to reduce the surface for flakiness and the overall pipeline runtime

Closes #401 