### PR TITLE
feat(element-snapshot): Extend support for content-nameable elements

### DIFF
--- a/.changeset/floppy-heads-kiss.md
+++ b/.changeset/floppy-heads-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Resolve accessible name from child content for elements with role `columnheader`, `rowheader`, `cell`, `gridcell`, `tab`, `option`, `term` and `definition`

--- a/.changeset/yummy-dots-tickle.md
+++ b/.changeset/yummy-dots-tickle.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": patch
+---
+
+Introduce separate `RegionSnapshot`

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-label_takes_precedence_over_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-label_takes_precedence_over_HTML_label.json
@@ -11,7 +11,6 @@
   },
   {
     "role": "label",
-    "name": "HTML Label",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-labelledby_takes_precedence_over_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/aria-labelledby_takes_precedence_over_HTML_label.json
@@ -11,7 +11,6 @@
   },
   {
     "role": "label",
-    "name": "HTML Label",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/referenced_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/referenced_HTML_label.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Label",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/accessible-name/surrounding_HTML_label.json
+++ b/packages/element-snapshot/data/integration-test/validation/accessible-name/surrounding_HTML_label.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Label",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/grid/grid.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/grid/grid.json
@@ -41,6 +41,7 @@
             "children": [
               {
                 "role": "rowheader",
+                "name": "Row Header 1",
                 "attributes": {},
                 "children": [
                   {
@@ -51,6 +52,7 @@
               },
               {
                 "role": "gridcell",
+                "name": "Grid Cell 1",
                 "attributes": {},
                 "children": [
                   {
@@ -67,6 +69,7 @@
             "children": [
               {
                 "role": "rowheader",
+                "name": "Row Header 2",
                 "attributes": {},
                 "children": [
                   {
@@ -77,6 +80,7 @@
               },
               {
                 "role": "gridcell",
+                "name": "Grid Cell 2",
                 "attributes": {},
                 "children": [
                   {

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/HTML_fieldset.json
@@ -6,7 +6,6 @@
     "children": [
       {
         "role": "label",
-        "name": "Legend",
         "attributes": {},
         "children": [
           {
@@ -17,7 +16,6 @@
       },
       {
         "role": "label",
-        "name": "First Name",
         "attributes": {},
         "children": [
           {
@@ -34,7 +32,6 @@
       },
       {
         "role": "label",
-        "name": "Last Name",
         "attributes": {},
         "children": [
           {

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/radiogroup.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/radiogroup.json
@@ -31,7 +31,6 @@
       },
       {
         "role": "label",
-        "name": "Option 1",
         "attributes": {},
         "children": [
           {
@@ -48,7 +47,6 @@
       },
       {
         "role": "label",
-        "name": "Option 2",
         "attributes": {},
         "children": [
           {

--- a/packages/element-snapshot/data/integration-test/validation/elements/group/role-based-group_without_name.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/group/role-based-group_without_name.json
@@ -5,7 +5,6 @@
     "children": [
       {
         "role": "label",
-        "name": "First Name",
         "attributes": {},
         "children": [
           {
@@ -22,7 +21,6 @@
       },
       {
         "role": "label",
-        "name": "Last Name",
         "attributes": {},
         "children": [
           {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Combobox",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_checkbox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_checkbox.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Checked",
     "attributes": {},
     "children": [
       {
@@ -20,7 +19,6 @@
   },
   {
     "role": "label",
-    "name": "Unchecked",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_date_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_date_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Date Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_email_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_email_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Email Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_file_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_file_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "File Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_multi_select.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Multi Select",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_number_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_number_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Number Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_password_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_password_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Password Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_radio_button.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_radio_button.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Yes",
     "attributes": {},
     "children": [
       {
@@ -20,7 +19,6 @@
   },
   {
     "role": "label",
-    "name": "No",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_range_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_range_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Range Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_search_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_search_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Search Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_single_select.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Single Select",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_text_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_text_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Text Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_textarea.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_textarea.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Textarea",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_time_input.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/HTML_time_input.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Time Input",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/input-based_combobox.json
@@ -1,7 +1,6 @@
 [
   {
     "role": "label",
-    "name": "Combobox",
     "attributes": {},
     "children": [
       {

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/HTML_table.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/HTML_table.json
@@ -47,6 +47,7 @@
             "children": [
               {
                 "role": "rowheader",
+                "name": "Row Header 1",
                 "attributes": {},
                 "children": [
                   {
@@ -57,6 +58,7 @@
               },
               {
                 "role": "cell",
+                "name": "Body Cell 1",
                 "attributes": {},
                 "children": [
                   {
@@ -73,6 +75,7 @@
             "children": [
               {
                 "role": "rowheader",
+                "name": "Row Header 2",
                 "attributes": {},
                 "children": [
                   {
@@ -83,6 +86,7 @@
               },
               {
                 "role": "cell",
+                "name": "Body Cell 2",
                 "attributes": {},
                 "children": [
                   {
@@ -105,6 +109,7 @@
             "children": [
               {
                 "role": "cell",
+                "name": "Footer Cell 1",
                 "attributes": {},
                 "children": [
                   {
@@ -115,6 +120,7 @@
               },
               {
                 "role": "cell",
+                "name": "Footer Cell 2",
                 "attributes": {},
                 "children": [
                   {

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/role-based_table.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/role-based_table.json
@@ -30,6 +30,7 @@
             "children": [
               {
                 "role": "rowheader",
+                "name": "Row Header",
                 "attributes": {},
                 "children": [
                   {
@@ -40,6 +41,7 @@
               },
               {
                 "role": "cell",
+                "name": "Cell",
                 "attributes": {},
                 "children": [
                   {

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/snapshots_empty_cells.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/snapshots_empty_cells.json
@@ -24,6 +24,7 @@
               },
               {
                 "role": "rowheader",
+                "name": "Row Header",
                 "attributes": {},
                 "children": [
                   {

--- a/packages/element-snapshot/src/browser/combobox.ts
+++ b/packages/element-snapshot/src/browser/combobox.ts
@@ -3,11 +3,7 @@ import { filterByRole } from "../utils/filter";
 
 import { resolveElementReference } from "./attribute";
 import { snapshotChildren } from "./children";
-import {
-  resolveInputLabel,
-  resolveInputValue,
-  snapshotCommonInputAttributes,
-} from "./input";
+import { resolveInputValue, snapshotCommonInputAttributes } from "./input";
 import { resolveAccessibleName } from "./name";
 import { disableableAttributes, selectableAttributes } from "./state";
 import { resolveAccessibleTextContent } from "./text";
@@ -26,7 +22,7 @@ export function snapshotCombobox(
 
   return {
     role: "combobox",
-    name: resolveInputLabel(element),
+    name: resolveAccessibleName(element),
     attributes: {
       value: resolveValue(element),
       ...snapshotCommonInputAttributes(element),

--- a/packages/element-snapshot/src/browser/container.ts
+++ b/packages/element-snapshot/src/browser/container.ts
@@ -9,8 +9,6 @@ import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
 import type { SnapshotTargetElement } from "./types";
 
-const NAMEABLE_CONTAINER_ROLES = new Set(["label"]);
-
 export function snapshotContainer(
   role: ContainerRole,
   element: SnapshotTargetElement,
@@ -19,7 +17,7 @@ export function snapshotContainer(
 
   return elementSnapshot({
     role,
-    name: resolveAccessibleName(element, NAMEABLE_CONTAINER_ROLES.has(role)),
+    name: resolveAccessibleName(element),
     children,
   });
 }

--- a/packages/element-snapshot/src/browser/dialog.ts
+++ b/packages/element-snapshot/src/browser/dialog.ts
@@ -18,7 +18,7 @@ function snapshotDialog(
 ): DialogSnapshot {
   return {
     role,
-    name: resolveAccessibleName(element, false),
+    name: resolveAccessibleName(element),
     attributes: {
       ...discribableAttributes(element),
       modal: booleanAttribute(element.ariaModal),

--- a/packages/element-snapshot/src/browser/element.ts
+++ b/packages/element-snapshot/src/browser/element.ts
@@ -15,6 +15,7 @@ import { snapshotInput } from "./input";
 import { snapshotLink } from "./link";
 import { snapshotMenuitem } from "./list";
 import { snapshotProgressbar } from "./progressbar";
+import { snapshotRegion } from "./region";
 import { parseElementRole } from "./role";
 import { snapshotSeparator } from "./separator";
 import { snapshotTab } from "./tab";
@@ -25,7 +26,7 @@ import { getElementTagName } from "./utils";
 
 type ElementSnapshotFn = (
   node: SnapshotTargetElement,
-) => ElementSnapshot | null;
+) => ElementSnapshot | Array<NodeSnapshot> | null;
 
 type NonContainerElementRole = Exclude<ElementRole, ContainerRole>;
 
@@ -45,6 +46,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   link: snapshotLink,
   radio: snapshotInput,
   radiogroup: snapshotRadioGroup,
+  region: snapshotRegion,
   searchbox: snapshotInput,
   separator: snapshotSeparator,
   slider: snapshotInput,

--- a/packages/element-snapshot/src/browser/group.ts
+++ b/packages/element-snapshot/src/browser/group.ts
@@ -7,7 +7,6 @@ import { elementSnapshot } from "../utils/factories";
 import { snapshotChildren } from "./children";
 import { discribableAttributes } from "./description";
 import { resolveAccessibleName } from "./name";
-import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
 
 export function snapshotGroup(
@@ -15,21 +14,9 @@ export function snapshotGroup(
 ): GroupSnapshot | null {
   return elementSnapshot({
     role: "group",
-    name: resolveGroupName(element),
+    name: resolveAccessibleName(element),
     children: snapshotChildren(element),
   });
-}
-
-function resolveGroupName(element: SnapshotTargetElement): string | undefined {
-  const legendElement =
-    element instanceof HTMLFieldSetElement
-      ? element.querySelector("legend")
-      : null;
-  if (legendElement !== null) {
-    return resolveAccessibleTextContent(legendElement);
-  }
-
-  return resolveAccessibleName(element, false);
 }
 
 export function snapshotRadioGroup(
@@ -37,7 +24,7 @@ export function snapshotRadioGroup(
 ): RadioGroupSnapshot {
   return {
     role: "radiogroup",
-    name: resolveAccessibleName(element, false),
+    name: resolveAccessibleName(element),
     attributes: discribableAttributes(element),
     children: snapshotChildren(element),
   };

--- a/packages/element-snapshot/src/browser/image.ts
+++ b/packages/element-snapshot/src/browser/image.ts
@@ -1,14 +1,13 @@
 import type { ImageSnapshot } from "../types/elements/image";
 import { elementSnapshot } from "../utils/factories";
 
-import { stringAttribute } from "./attribute";
 import { resolveAccessibleName } from "./name";
 import type { SnapshotTargetElement } from "./types";
 
 export function snapshotImage(
   element: SnapshotTargetElement,
 ): ImageSnapshot | null {
-  const imageName = resolveImageName(element);
+  const imageName = resolveAccessibleName(element);
 
   if (imageName === undefined) {
     return null;
@@ -18,12 +17,4 @@ export function snapshotImage(
     role: "img",
     name: imageName,
   });
-}
-
-function resolveImageName(element: SnapshotTargetElement): string | undefined {
-  if (element instanceof HTMLImageElement) {
-    return stringAttribute(element.alt);
-  }
-
-  return resolveAccessibleName(element, true);
 }

--- a/packages/element-snapshot/src/browser/input.ts
+++ b/packages/element-snapshot/src/browser/input.ts
@@ -9,7 +9,6 @@ import { discribableAttributes } from "./description";
 import { resolveAccessibleName } from "./name";
 import { resolveInputRole } from "./role";
 import { inputStateAttributes } from "./state";
-import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
 
 type InputElement =
@@ -45,7 +44,7 @@ function snapshotInputElement(element: HTMLInputElement): InputSnapshot | null {
 
   return elementSnapshot({
     role: inputRole,
-    name: resolveInputLabel(element),
+    name: resolveAccessibleName(element),
     attributes: {
       value: resolveInputValue(element),
       checked: resolveChecked(element),
@@ -57,7 +56,7 @@ function snapshotInputElement(element: HTMLInputElement): InputSnapshot | null {
 function snapshotTextareaElement(element: HTMLTextAreaElement): InputSnapshot {
   return elementSnapshot({
     role: "textbox",
-    name: resolveInputLabel(element),
+    name: resolveAccessibleName(element),
     attributes: {
       value: resolveInputValue(element),
       ...snapshotCommonInputAttributes(element),
@@ -98,31 +97,6 @@ function resolveChecked(
   }
 
   return element.checked ? true : undefined;
-}
-
-export function resolveInputLabel(
-  element: SnapshotTargetElement,
-): string | undefined {
-  const accessibleName = resolveAccessibleName(element, false);
-  if (accessibleName !== undefined) {
-    return accessibleName;
-  }
-
-  if (element.id !== null) {
-    const referencedElement = element.ownerDocument.querySelector(
-      `[for='${element.id}']`,
-    );
-    if (referencedElement !== null) {
-      return resolveAccessibleTextContent(referencedElement);
-    }
-  }
-
-  const closestLabel = element.closest("label");
-  if (closestLabel !== null) {
-    return resolveAccessibleTextContent(closestLabel, [element]);
-  }
-
-  return undefined;
 }
 
 function resolvePlaceholder(element: InputElement): string | undefined {

--- a/packages/element-snapshot/src/browser/name.ts
+++ b/packages/element-snapshot/src/browser/name.ts
@@ -1,11 +1,65 @@
-import { resolveElementReference } from "./attribute";
+import type { ElementRole } from "../types/role";
+
+import { resolveElementReference, stringAttribute } from "./attribute";
+import { parseElementRole } from "./role";
+import { attributeSelector } from "./selector";
 import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
 
+// See https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#accessiblenameguidancebyrole
+const prohibitsNaming = new Set<ElementRole>([
+  "label",
+  "listitem",
+  "paragraph",
+  "rowgroup",
+  "term",
+]);
+
+const supportsNamingByLabel = new Set<ElementRole>([
+  "checkbox",
+  "combobox",
+  "progressbar",
+  "radio",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "textbox",
+]);
+
+const supportsNamingFromChildContent = new Set<ElementRole>([
+  "button",
+  "cell",
+  "columnheader",
+  "gridcell",
+  "heading",
+  "link",
+  "menuitem",
+  "option",
+  "rowheader",
+  "tab",
+]);
+
+const contextBasedNameResolvers: Array<ContextBasedNameResolver> = [
+  resolveImageName,
+  resolveLegendName,
+];
+
+type ContextBasedNameResolver = (
+  element: SnapshotTargetElement,
+  role: ElementRole,
+) => string | undefined;
+
+// Inspired by https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#name_calculation
 export function resolveAccessibleName(
   element: SnapshotTargetElement,
-  includeTextContent = true,
+  role?: ElementRole,
 ): string | undefined {
+  role = role ?? parseElementRole(element);
+
+  if (role === undefined || prohibitsNaming.has(role)) {
+    return undefined;
+  }
+
   const labelledByElement = resolveElementReference(element, "aria-labelledby");
   if (labelledByElement !== null) {
     return resolveAccessibleTextContent(labelledByElement);
@@ -15,7 +69,64 @@ export function resolveAccessibleName(
     return element.ariaLabel;
   }
 
-  if (includeTextContent) {
+  for (const resolveName of contextBasedNameResolvers) {
+    const name = resolveName(element, role);
+    if (name !== undefined) {
+      return name;
+    }
+  }
+
+  if (supportsNamingByLabel.has(role)) {
+    return resolveLabelName(element);
+  }
+
+  if (supportsNamingFromChildContent.has(role)) {
+    return resolveAccessibleTextContent(element);
+  }
+
+  return undefined;
+}
+
+function resolveLabelName(element: SnapshotTargetElement): string | undefined {
+  if (element.id !== null) {
+    const referencedElement = element.ownerDocument.querySelector(
+      attributeSelector("for", element.id),
+    );
+    if (referencedElement !== null) {
+      return resolveAccessibleTextContent(referencedElement);
+    }
+  }
+
+  const closestLabel = element.closest("label");
+  if (closestLabel !== null) {
+    return resolveAccessibleTextContent(closestLabel, [element]);
+  }
+
+  return undefined;
+}
+
+function resolveLegendName(element: SnapshotTargetElement): string | undefined {
+  if (!(element instanceof HTMLFieldSetElement)) {
+    return undefined;
+  }
+
+  const legendElement = element.querySelector("legend");
+  if (legendElement === null) {
+    return undefined;
+  }
+
+  return resolveAccessibleTextContent(legendElement);
+}
+
+function resolveImageName(
+  element: SnapshotTargetElement,
+  role: ElementRole,
+): string | undefined {
+  if (element instanceof HTMLImageElement) {
+    return stringAttribute(element.alt);
+  }
+
+  if (role === "img") {
     return resolveAccessibleTextContent(element);
   }
 

--- a/packages/element-snapshot/src/browser/name.ts
+++ b/packages/element-snapshot/src/browser/name.ts
@@ -52,9 +52,8 @@ type ContextBasedNameResolver = (
 // Inspired by https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#name_calculation
 export function resolveAccessibleName(
   element: SnapshotTargetElement,
-  role?: ElementRole,
 ): string | undefined {
-  role = role ?? parseElementRole(element);
+  const role = parseElementRole(element);
 
   if (role === undefined || prohibitsNaming.has(role)) {
     return undefined;

--- a/packages/element-snapshot/src/browser/progressbar.ts
+++ b/packages/element-snapshot/src/browser/progressbar.ts
@@ -10,7 +10,7 @@ export function snapshotProgressbar(
 ): ProgressbarSnapshot {
   return {
     role: "progressbar",
-    name: resolveAccessibleName(element, false),
+    name: resolveAccessibleName(element),
     attributes: {
       value: resolveValue(element),
     },

--- a/packages/element-snapshot/src/browser/region.ts
+++ b/packages/element-snapshot/src/browser/region.ts
@@ -1,0 +1,24 @@
+import type { RegionSnapshot } from "../types/elements/container";
+import type { NodeSnapshot } from "../types/snapshot";
+import { elementSnapshot } from "../utils/factories";
+
+import { snapshotChildren } from "./children";
+import { resolveAccessibleName } from "./name";
+import type { SnapshotTargetElement } from "./types";
+
+export function snapshotRegion(
+  element: SnapshotTargetElement,
+): RegionSnapshot | Array<NodeSnapshot> {
+  const name = resolveAccessibleName(element);
+  const children = snapshotChildren(element);
+
+  if (name === undefined) {
+    return children;
+  }
+
+  return elementSnapshot({
+    role: "region",
+    name,
+    children,
+  });
+}

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -3,7 +3,6 @@ import type { ElementRole } from "../types/role";
 
 import { isContainerRole } from "./container";
 import { hasRoleSpecificSnapshot } from "./element";
-import { resolveAccessibleName } from "./name";
 import { roleSelector, selectorList } from "./selector";
 import type { ElementTagName, SnapshotTargetElement } from "./types";
 import { getElementTagName, isWithinElement } from "./utils";
@@ -71,7 +70,6 @@ const CONTEXT_DEPENDENT_ROLES: Partial<
   gridcell: isWithinGridRow,
   listitem: isWithinList,
   menuitem: isWithinMenu,
-  region: hasAccessibleName,
   row: isWithinTableOrGrid,
   rowgroup: isWithinTableOrGrid,
   rowheader: isWithinTableRowOrGridRow,
@@ -190,14 +188,6 @@ function isTopLevelBanner(element: SnapshotTargetElement): boolean {
     ...DISALLOWED_BANNER_CONTAINER_ROLES.map(roleSelector),
   );
   return !isWithinElement(element, disallowedContainerSelector);
-}
-
-function hasAccessibleName(
-  element: SnapshotTargetElement,
-  role: ElementRole,
-): boolean {
-  const accessibleName = resolveAccessibleName(element, role);
-  return accessibleName !== undefined;
 }
 
 function isWithinDescriptionList(element: SnapshotTargetElement): boolean {

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -1,4 +1,4 @@
-import type { InputRole } from "../types/elements/input";
+import type { CommonInputRole, InputRole } from "../types/elements/input";
 import type { ElementRole } from "../types/role";
 
 import { isContainerRole } from "./container";
@@ -12,7 +12,10 @@ type ElementRoleResolver<TRoles = ElementRole> =
   | TRoles
   | ((element: SnapshotTargetElement) => TRoles | undefined);
 
-type ElementContextValidator = (element: SnapshotTargetElement) => boolean;
+type ElementContextValidator = (
+  element: SnapshotTargetElement,
+  role: ElementRole,
+) => boolean;
 
 const ELEMENT_ROLES: Partial<Record<ElementTagName, ElementRoleResolver>> = {
   a: "link",
@@ -76,7 +79,10 @@ const CONTEXT_DEPENDENT_ROLES: Partial<
   term: isWithinDescriptionList,
 };
 
-const INPUT_ROLES: Record<string, ElementRoleResolver<InputRole | "button">> = {
+const INPUT_ROLES: Record<
+  string,
+  ElementRoleResolver<CommonInputRole | "button">
+> = {
   button: "button",
   checkbox: "checkbox",
   email: "textbox",
@@ -101,7 +107,10 @@ export function parseElementRole(
   }
 
   const isValidInContext = CONTEXT_DEPENDENT_ROLES[resolvedElementRole];
-  if (isValidInContext !== undefined && !isValidInContext(element)) {
+  if (
+    isValidInContext !== undefined &&
+    !isValidInContext(element, resolvedElementRole)
+  ) {
     return undefined;
   }
 
@@ -183,8 +192,11 @@ function isTopLevelBanner(element: SnapshotTargetElement): boolean {
   return !isWithinElement(element, disallowedContainerSelector);
 }
 
-function hasAccessibleName(element: SnapshotTargetElement): boolean {
-  const accessibleName = resolveAccessibleName(element, false);
+function hasAccessibleName(
+  element: SnapshotTargetElement,
+  role: ElementRole,
+): boolean {
+  const accessibleName = resolveAccessibleName(element, role);
   return accessibleName !== undefined;
 }
 

--- a/packages/element-snapshot/src/browser/selector.ts
+++ b/packages/element-snapshot/src/browser/selector.ts
@@ -8,6 +8,6 @@ export function roleSelector(roleName: ElementRole): string {
   return attributeSelector("role", roleName);
 }
 
-function attributeSelector(name: string, value: string): string {
+export function attributeSelector(name: string, value: string): string {
   return `[${name}='${value}']`;
 }

--- a/packages/element-snapshot/src/index.ts
+++ b/packages/element-snapshot/src/index.ts
@@ -2,7 +2,10 @@ export type { ElementRole } from "./types/role";
 export type { ElementSnapshot, NodeRole, NodeSnapshot } from "./types/snapshot";
 export type { TextSnapshot } from "./types/elements/text";
 export type { ButtonSnapshot } from "./types/elements/button";
-export type { ContainerSnapshot } from "./types/elements/container";
+export type {
+  ContainerSnapshot,
+  RegionSnapshot,
+} from "./types/elements/container";
 export type { DialogSnapshot } from "./types/elements/dialog";
 export type { GroupSnapshot, RadioGroupSnapshot } from "./types/elements/group";
 export type { HeadingSnapshot } from "./types/elements/heading";

--- a/packages/element-snapshot/src/playwright/markdown-table.ts
+++ b/packages/element-snapshot/src/playwright/markdown-table.ts
@@ -7,10 +7,14 @@ import {
 } from "@cronn/lib-file-snapshots";
 
 import type { ColumnHeaderSnapshot, SortType } from "../types/elements/table";
-import type { NodeRole, NodeSnapshot, SnapshotByRole } from "../types/snapshot";
+import type {
+  ElementSnapshot,
+  NodeRole,
+  NodeSnapshot,
+  SnapshotByRole,
+} from "../types/snapshot";
 import { filter, filterByRole } from "../utils/filter";
 import { includeRole } from "../utils/predicates";
-import { getTextContent } from "../utils/text";
 
 import { rawSnapshot } from "./snapshot";
 
@@ -87,7 +91,7 @@ function getColumnHeaderText(
   columnHeader: ColumnHeaderSnapshot,
   showSortIndicator: boolean,
 ): string {
-  const headerText = getTextContent([columnHeader]);
+  const headerText = getNameOrDefault(columnHeader);
   const sortType = columnHeader.attributes.sort;
 
   if (!showSortIndicator || sortType === undefined) {
@@ -102,5 +106,9 @@ function getCellTexts(row: SnapshotByRole<"row">): TableRow {
   return filter({
     predicate: includeRole(cellRoles),
     snapshots: row.children,
-  }).map((cell) => getTextContent(cell.children));
+  }).map(getNameOrDefault);
+}
+
+function getNameOrDefault(snapshot: ElementSnapshot): string {
+  return snapshot.name ?? "";
 }

--- a/packages/element-snapshot/src/types/elements/container.ts
+++ b/packages/element-snapshot/src/types/elements/container.ts
@@ -13,7 +13,6 @@ export const CONTAINER_ROLES = new Set([
   "form",
   "main",
   "navigation",
-  "region",
   "search",
   "descriptionlist",
   "term",
@@ -35,3 +34,5 @@ export const CONTAINER_ROLES = new Set([
 export interface ContainerSnapshot extends GenericElementSnapshot<ContainerRole> {}
 
 export type ContainerRole = SetValues<typeof CONTAINER_ROLES>;
+
+export interface RegionSnapshot extends GenericElementSnapshot<"region"> {}

--- a/packages/element-snapshot/src/types/role.ts
+++ b/packages/element-snapshot/src/types/role.ts
@@ -15,6 +15,7 @@ export type ElementRole =
   | "option"
   | "progressbar"
   | "radiogroup"
+  | "region"
   | "separator"
   | "tab"
   | ContainerRole

--- a/packages/element-snapshot/src/types/snapshot.ts
+++ b/packages/element-snapshot/src/types/snapshot.ts
@@ -1,5 +1,5 @@
 import type { ButtonSnapshot } from "./elements/button";
-import type { ContainerSnapshot } from "./elements/container";
+import type { ContainerSnapshot, RegionSnapshot } from "./elements/container";
 import type { DialogSnapshot } from "./elements/dialog";
 import type { GroupSnapshot, RadioGroupSnapshot } from "./elements/group";
 import type { HeadingSnapshot } from "./elements/heading";
@@ -49,6 +49,7 @@ export type ElementSnapshot =
   | LinkSnapshot
   | OptionSnapshot
   | ProgressbarSnapshot
+  | RegionSnapshot
   | TabSnapshot
   | MenuItemSnapshot
   | RadioGroupSnapshot

--- a/packages/element-snapshot/tests/elements/image.spec.ts
+++ b/packages/element-snapshot/tests/elements/image.spec.ts
@@ -26,10 +26,6 @@ test("role-based image with label", async ({ page }) => {
   );
 });
 
-test("role-based image with text content", async ({ page }) => {
-  await matchRawElementSnapshot(page, html`<div role="img">Text</div>`);
-});
-
 test("ignores image without name", async ({ page }) => {
   await matchRawElementSnapshot(page, html`<img src="image.jpg" />`);
 });


### PR DESCRIPTION
This PR extends the support for elements  which can be named by the content of their children. This facilitates deriving custom snapshot formats using the names of elements (see changes in the Markdown table snapshot). In contrast to `getTextContent`, the name resolving follows a role-dependent algorithm, which is more reliable and closely follows the official specification.

As part of the PR, the name resolving was centralized and is now derived from the passed element. This ensures consistency and avoids passing wrong parameters.

Closes #351 