### PR TITLE
Migrate to pnpm v11

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
       uses: actions/setup-node@v6

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# add new dependencies with exact version instead of semver ranges
-save-exact=true

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
       "entry": [".meta-updater/main.mjs"]
     }
   },
+  "ignoreBinaries": ["clean-install"],
   "ignoreDependencies": [
     "@trivago/prettier-plugin-sort-imports",
     "eslint-config-prettier",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/cronn/file-snapshots.git"
   },
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -21,7 +21,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/aria-snapshot"
   },
   "homepage": "https://cronn.github.io/file-snapshots/playwright/aria-snapshots",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -25,7 +25,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/docs"
   },
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -22,7 +22,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/element-snapshot/package.json
+++ b/packages/element-snapshot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/element-snapshot"
   },
   "homepage": "https://cronn.github.io/file-snapshots/playwright/element-snapshots/",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -25,7 +25,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/lib-file-snapshots"
   },
   "homepage": "https://github.com/cronn/file-snapshots",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -28,7 +28,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/meta-updater/package.json
+++ b/packages/meta-updater/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/meta-updater"
   },
   "homepage": "https://github.com/cronn/file-snapshots",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -23,7 +23,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/meta-updater/src/update-package-json.ts
+++ b/packages/meta-updater/src/update-package-json.ts
@@ -21,7 +21,7 @@ export function updatePackageJson(
     license: "Apache-2.0",
     repository: defineRepository(context),
     homepage: manifest.homepage ?? "https://github.com/cronn/file-snapshots",
-    packageManager: "pnpm@10.33.0",
+    packageManager: "pnpm@11.0.1",
     engines: {
       node: "^20 || ^22 || >=24",
     },
@@ -33,7 +33,7 @@ export function updatePackageJson(
       },
       packageManager: {
         name: "pnpm",
-        version: ">=10.33.0 <11",
+        version: ">=11 <12",
         onFail: "error",
       },
     },

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/playwright-file-snapshots"
   },
   "homepage": "https://cronn.github.io/file-snapshots/playwright/",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -29,7 +29,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/shared-configs"
   },
   "homepage": "https://github.com/cronn/file-snapshots",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -23,7 +23,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/test-utils"
   },
   "homepage": "https://github.com/cronn/file-snapshots",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -23,7 +23,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/vitest-file-snapshots"
   },
   "homepage": "https://cronn.github.io/file-snapshots/vitest/",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
@@ -29,7 +29,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.33.0 <11",
+      "version": ">=11 <12",
       "onFail": "error"
     }
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-blockExoticSubdeps: true
-
 packages:
   - packages/*
+allowBuilds:
+  esbuild: false
 
 catalog:
   "@arethetypeswrong/core": 0.18.2
@@ -30,11 +30,8 @@ catalog:
   "vitepress": 1.6.4
   "vitest": 4.1.4
   "yaml": 2.8.3
-
 dedupePeers: true
 
-ignoredBuiltDependencies:
-  - esbuild
 includeWorkspaceRoot: true
 
 minimumReleaseAge: 10080 # 1 week
@@ -48,7 +45,7 @@ overrides:
   "esbuild": ">=0.25.0"
   "vite": ">=8.0.5"
 
-strictDepBuilds: true
+saveExact: true
 
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 40320 # 4 weeks

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+blockExoticSubdeps: true
+
 packages:
   - packages/*
 
@@ -8,15 +10,15 @@ catalog:
   "@playwright/test": 1.59.1
   "@pnpm/meta-updater": 2.0.6
   "@trivago/prettier-plugin-sort-imports": 6.0.2
-  "@typescript/native-preview": 7.0.0-dev.20260420.1
   "@types/node": 24.12.2
+  "@typescript/native-preview": 7.0.0-dev.20260420.1
   "@vitest/coverage-v8": 4.1.4
   "@vitest/expect": 4.1.4
-  "knip": 6.5.0
   "eslint": 10.2.1
   "eslint-config-prettier": 10.1.8
   "eslint-plugin-check-file": 3.3.1
   "eslint-plugin-unused-imports": 4.4.1
+  "knip": 6.5.0
   "markdown-table": 3.0.4
   "package-directory": 8.2.0
   "prettier": 3.8.3
@@ -29,25 +31,24 @@ catalog:
   "vitest": 4.1.4
   "yaml": 2.8.3
 
-overrides:
-  "@types/node": "<25"
-  "cross-spawn": ">=7.0.5"
-  "esbuild": ">=0.25.0"
-  "vite": ">=8.0.5"
-
-includeWorkspaceRoot: true
 dedupePeers: true
-
-strictDepBuilds: true
 
 ignoredBuiltDependencies:
   - esbuild
+includeWorkspaceRoot: true
 
 minimumReleaseAge: 10080 # 1 week
 minimumReleaseAgeExclude:
   - "@eslint/config-helpers@0.5.5"
   - "@eslint/core@1.2.1"
 
+overrides:
+  "@types/node": "<25"
+  "cross-spawn": ">=7.0.5"
+  "esbuild": ">=0.25.0"
+  "vite": ">=8.0.5"
+
+strictDepBuilds: true
+
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 40320 # 4 weeks
-blockExoticSubdeps: true


### PR DESCRIPTION
This PR migrates the monorepo to pnpm v11.

## Notable changes

- `strictDepBuilds` and `blockExoticSubdeps` default to  `true`
- New `clean` and `clean-install` commands
- Native publishing without `npm`
- Removed pnpm-specific configuration via `.npmrc`

## Follow-ups

- [Publish via pnpm](https://github.com/cronn/file-snapshots/issues/418)
- [Use `pnpm clean-install` in CI](https://github.com/cronn/file-snapshots/issues/420) (currently produces build errors)
- [Integrate `pnpm clean` command](https://github.com/cronn/file-snapshots/issues/417)

> [!NOTE]
> pnpm now displays a warning when using the deprecated `packageManager` field. We still use this field, because Turbopack does not yet support `devEngines.packageManager` as an alternative ([see discussion](https://github.com/vercel/turborepo/discussions/10848)).