### PR TITLE
chore: Use exact pnpm version in devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -47,5 +47,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -63,7 +63,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -75,5 +75,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -34,7 +34,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -46,5 +46,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/element-snapshot/package.json
+++ b/packages/element-snapshot/package.json
@@ -65,7 +65,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -77,5 +77,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -58,7 +58,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -70,5 +70,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/meta-updater/package.json
+++ b/packages/meta-updater/package.json
@@ -37,7 +37,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -49,5 +49,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/meta-updater/src/update-package-json.ts
+++ b/packages/meta-updater/src/update-package-json.ts
@@ -21,14 +21,14 @@ export function updatePackageJson(
     license: "Apache-2.0",
     repository: defineRepository(context),
     homepage: manifest.homepage ?? "https://github.com/cronn/file-snapshots",
-    packageManager: "pnpm@11.0.1",
+    packageManager: "pnpm@11.0.7",
     engines: {
       node: "^20 || ^22 || >=24",
     },
     devEngines: {
       packageManager: {
         name: "pnpm",
-        version: ">=11 <12",
+        version: "11.0.7",
         onFail: "download",
       },
       runtime: {

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -69,7 +69,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -81,5 +81,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -51,7 +51,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -63,5 +63,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -42,7 +42,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -54,5 +54,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -71,7 +71,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11 <12",
+      "version": "11.0.7",
       "onFail": "download"
     },
     "runtime": {
@@ -83,5 +83,5 @@
   "engines": {
     "node": "^20 || ^22 || >=24"
   },
-  "packageManager": "pnpm@11.0.1"
+  "packageManager": "pnpm@11.0.7"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: '>=11 <12'
-        version: 11.0.5
+        specifier: 11.0.7
+        version: 11.0.7
       pnpm:
-        specifier: '>=11 <12'
-        version: 11.0.5
+        specifier: 11.0.7
+        version: 11.0.7
 
 packages:
 
-  '@pnpm/exe@11.0.5':
-    resolution: {integrity: sha512-6hfKxb85pbW2IJ9WAZRQfC+7luwU3GGse04yWsjLlJXfHp4WSMWtelKY4DLXFg09xxnynoQ2lYdJOswU2nFTmw==}
+  '@pnpm/exe@11.0.7':
+    resolution: {integrity: sha512-zD5EMUePXPGAg4yKj1xEVQXIAOeIGuQh0YXo86t3n5fRmqDVwnGMAqZDBMdSXwXS/uvLpmserl6j9jqoeGlQUQ==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.0.5':
-    resolution: {integrity: sha512-oFKn1vicMPFfI7qJLX7UxShVK3h5EG1JQTtXvXzs0Qt3GECPtle9Ts3nFz7an2VOP9uhN/sUbLV9vaGFZxSEAg==}
+  '@pnpm/linux-arm64@11.0.7':
+    resolution: {integrity: sha512-Opx5npdHf8m3MS16yodVWcFjoaQ0N9FO9OQpdT3Ks7FxRNtp4T4VBRqlqlXfUA35CroTh22cXLZn3ByIT0MSDw==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.0.5':
-    resolution: {integrity: sha512-j3kN0ZTJypoIXLH8fK2k3m28amEhNMFEB2asP1I9Sc81ntvOkataFDWwDjlb5WsyTaqOu5CsAYjauFMQCVbXFA==}
+  '@pnpm/linux-x64@11.0.7':
+    resolution: {integrity: sha512-+D8XIEC2fp9dKKR2emGjzPcsJB9Xw/rXqzVayyphBbaPu6J+JytET4kYHIsM1EeJ7o6UkmAXjPLmgc6Bxu11EQ==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.0.5':
-    resolution: {integrity: sha512-7AK2qyd3uPIQYhaRIiTIB446ret+k/pZ6Gk5dsIJETlIZLG/zZ7xTx5rF3YxFgGwvs4jfciod/uYz7IczpQ7oQ==}
+  '@pnpm/linuxstatic-arm64@11.0.7':
+    resolution: {integrity: sha512-EePML7trF6ygvIZpvmCX4ykYsiw3J5k6aiG4uIAi7gJ8N1ZFHrZiqJVXlQPek6XVaeLNu4gaAORi1P3b4M68HA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.0.5':
-    resolution: {integrity: sha512-9AO2sBcPv7BLNlhUJiOcLaFZwhUwDCf1IFMpN80skZGwVo2blucUQMYuWFidR0vy7YvLcR15KoN6z+h2QzrL2g==}
+  '@pnpm/linuxstatic-x64@11.0.7':
+    resolution: {integrity: sha512-XwrdZAdn5ArA3yWnvMIabKCFGoZrahvY/q9FjRXKPyN1hiAuzdITBZW+w1ywq8lgLBJT+2acgpafuiQKol/0lA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.0.5':
-    resolution: {integrity: sha512-trKLmXxOTof0k/QJxBJrPyWLvNaes10CUh7dGcHwVPqwpBnjXaRbaD8VEswP4kvyzu//1eiATTZSz/TczAMxnw==}
+  '@pnpm/macos-arm64@11.0.7':
+    resolution: {integrity: sha512-dBnXwHY3flGveXgc+aAqr0jTddNJZIktAV8HmEalLty5bQQKi9bxNeCoMGImRjocgqc6on5wg1bNr9IdqwbhpQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.0.5':
-    resolution: {integrity: sha512-jNTV5a9y56HRDyDZfk4EL4IfigeG1JlJNJx9/DhBX7yLsCSmE4NENtTnRD8R1uUu+o5WPrPas/4sZt6bzuxzAQ==}
+  '@pnpm/win-arm64@11.0.7':
+    resolution: {integrity: sha512-Mg7hgalpv+55g0rqJgFKx5b4YuCF8i8AE9w8bHmAsx8Ezwe3fmIg8tubAIiH78ccUZN8vZ5Gp2x/h2fE+jH0+A==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.0.5':
-    resolution: {integrity: sha512-Cy8PqWcMQuLHa5pFb9iXSDzu5Kv7mS/ECjVebmyI2b+3gIZV4vq+NuPpJZvFqf3kbFoEGnLFZE0fYDQHHXXPoA==}
+  '@pnpm/win-x64@11.0.7':
+    resolution: {integrity: sha512-nKEgq5TsQSmfZdwbQlAaH1gft1VxjWE46y0sixQJrsXhHL+t8VP+kLmMF76T5kW4kMynSv3SSyEx7stK4n8ecA==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.0.5:
-    resolution: {integrity: sha512-lPoJ5yAWQCrvzniORplOGOsZIpmLFrb9Wqa6/Yrk3qBdCFL2Akf9t9WrgZmnsL7agwOY8/gMufgiOYUioVNUgQ==}
+  pnpm@11.0.7:
+    resolution: {integrity: sha512-ckp7XSMZzdcAnWXhWiwpqunTkCtQWFyhY9OKdzfrhbxOchloef9Zdopx6B/jKqcei3DwiLLiS55KKFDYfkYHtQ==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.0.5':
+  '@pnpm/exe@11.0.7':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.5
-      '@pnpm/linux-x64': 11.0.5
-      '@pnpm/linuxstatic-arm64': 11.0.5
-      '@pnpm/linuxstatic-x64': 11.0.5
-      '@pnpm/macos-arm64': 11.0.5
-      '@pnpm/win-arm64': 11.0.5
-      '@pnpm/win-x64': 11.0.5
+      '@pnpm/linux-arm64': 11.0.7
+      '@pnpm/linux-x64': 11.0.7
+      '@pnpm/linuxstatic-arm64': 11.0.7
+      '@pnpm/linuxstatic-x64': 11.0.7
+      '@pnpm/macos-arm64': 11.0.7
+      '@pnpm/win-arm64': 11.0.7
+      '@pnpm/win-x64': 11.0.7
 
-  '@pnpm/linux-arm64@11.0.5':
+  '@pnpm/linux-arm64@11.0.7':
     optional: true
 
-  '@pnpm/linux-x64@11.0.5':
+  '@pnpm/linux-x64@11.0.7':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.0.5':
+  '@pnpm/linuxstatic-arm64@11.0.7':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.0.5':
+  '@pnpm/linuxstatic-x64@11.0.7':
     optional: true
 
-  '@pnpm/macos-arm64@11.0.5':
+  '@pnpm/macos-arm64@11.0.7':
     optional: true
 
-  '@pnpm/win-arm64@11.0.5':
+  '@pnpm/win-arm64@11.0.7':
     optional: true
 
-  '@pnpm/win-x64@11.0.5':
+  '@pnpm/win-x64@11.0.7':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.0.5: {}
+  pnpm@11.0.7: {}
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
This prevents the warning while using both `packageManager` and `devEngines.packageManager`, see https://github.com/pnpm/pnpm/issues/11301.