### PR TITLE
chore: Enable declaration maps

### DIFF
--- a/.changeset/spotty-lands-find.md
+++ b/.changeset/spotty-lands-find.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": patch
+---
+
+Export `PlaywrightValidationFileMatchers` interface

--- a/packages/aria-snapshot/tsdown.config.ts
+++ b/packages/aria-snapshot/tsdown.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) => [
-  tsdownConfig({
-    entry: ["src/index.ts"],
-    ...options,
-  }),
+export default defineConfig((options, context) => [
+  tsdownConfig(
+    {
+      entry: ["src/index.ts"],
+      ...options,
+    },
+    context,
+  ),
 ]);

--- a/packages/element-snapshot/tsdown.config.ts
+++ b/packages/element-snapshot/tsdown.config.ts
@@ -2,21 +2,24 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) => [
-  tsdownConfig({
-    entry: ["src/index.ts"],
-    format: {
-      esm: {
-        entry: {
-          index: "src/index.ts",
+export default defineConfig((options, context) => [
+  tsdownConfig(
+    {
+      entry: ["src/index.ts"],
+      format: {
+        esm: {
+          entry: {
+            index: "src/index.ts",
+          },
+        },
+        iife: {
+          entry: {
+            "browser-lib": "src/browser-lib.ts",
+          },
         },
       },
-      iife: {
-        entry: {
-          "browser-lib": "src/browser-lib.ts",
-        },
-      },
+      ...options,
     },
-    ...options,
-  }),
+    context,
+  ),
 ]);

--- a/packages/lib-file-snapshots/tsdown.config.ts
+++ b/packages/lib-file-snapshots/tsdown.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) =>
-  tsdownConfig({
-    entry: ["src/index.ts"],
-    ...options,
-  }),
+export default defineConfig((options, context) =>
+  tsdownConfig(
+    {
+      entry: ["src/index.ts"],
+      ...options,
+    },
+    context,
+  ),
 );

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -3,6 +3,7 @@ export type {
   PlaywrightMatchValidationFileOptions,
   PlaywrightMatchTextFileOptions,
   PlaywrightMatchJsonFileOptions,
+  PlaywrightValidationFileMatchers,
 } from "./matchers/types";
 
 export {

--- a/packages/playwright-file-snapshots/tsdown.config.ts
+++ b/packages/playwright-file-snapshots/tsdown.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) =>
-  tsdownConfig({
-    entry: ["src/index.ts"],
-    ...options,
-  }),
+export default defineConfig((options, context) =>
+  tsdownConfig(
+    {
+      entry: ["src/index.ts"],
+      ...options,
+    },
+    context,
+  ),
 );

--- a/packages/shared-configs/src/tsdown.ts
+++ b/packages/shared-configs/src/tsdown.ts
@@ -1,10 +1,19 @@
 import type { UserConfig } from "tsdown";
 
-export function tsdownConfig(options: UserConfig): UserConfig {
+interface TsdownContext {
+  ci: boolean;
+}
+
+export function tsdownConfig(
+  options: UserConfig,
+  context: TsdownContext,
+): UserConfig {
   return {
     platform: "node",
     format: ["esm"],
-    dts: true,
+    dts: {
+      sourcemap: !context.ci,
+    },
     outDir: "./dist",
     clean: true,
     deps: {

--- a/packages/test-utils/tsdown.config.ts
+++ b/packages/test-utils/tsdown.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) =>
-  tsdownConfig({
-    entry: ["src/playwright.ts"],
-    ...options,
-  }),
+export default defineConfig((options, context) =>
+  tsdownConfig(
+    {
+      entry: ["src/playwright.ts"],
+      ...options,
+    },
+    context,
+  ),
 );

--- a/packages/vitest-file-snapshots/tsdown.config.ts
+++ b/packages/vitest-file-snapshots/tsdown.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from "tsdown";
 
 import { tsdownConfig } from "@cronn/shared-configs/tsdown";
 
-export default defineConfig((options) =>
-  tsdownConfig({
-    entry: ["src/index.ts", "src/register.ts"],
-    ...options,
-  }),
+export default defineConfig((options, context) =>
+  tsdownConfig(
+    {
+      entry: ["src/index.ts", "src/register.ts"],
+      ...options,
+    },
+    context,
+  ),
 );

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,8 @@
     "lib": ["esnext"],
     "moduleResolution": "bundler",
     "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
     "noEmit": true
   }
 }


### PR DESCRIPTION
Enables TypeScript declaration maps to easily navigate to the sources within the monorepo during development.