### PR TITLE
feat(aria-snapshot): Provide ARIA snapshot matcher

### DIFF
--- a/.changeset/brave-forks-sort.md
+++ b/.changeset/brave-forks-sort.md
@@ -1,0 +1,5 @@
+---
+"@cronn/aria-snapshot": major
+---
+
+Breaking change: Rename `snapshotAria` to `ariaSnapshot`

--- a/.changeset/early-aliens-hammer.md
+++ b/.changeset/early-aliens-hammer.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": major
+---
+
+Breaking change: Rename `defineValidationFileExpect` to `defineFileSnapshotMatchers`

--- a/.changeset/early-pumas-eat.md
+++ b/.changeset/early-pumas-eat.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Breaking change: Rename `defineElementSnapshotExpect` to `defineElementSnapshotMatchers`

--- a/.changeset/modern-suits-sit.md
+++ b/.changeset/modern-suits-sit.md
@@ -1,0 +1,5 @@
+---
+"@cronn/vitest-file-snapshots": major
+---
+
+Breaking change: Rename `registerValidationFileMatchers` to `registerFileSnapshotMatchers`

--- a/.changeset/neat-pans-kneel.md
+++ b/.changeset/neat-pans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cronn/aria-snapshot": major
+---
+
+Provide `toMatchAriaSnapshotFile` matcher

--- a/packages/aria-snapshot/README.md
+++ b/packages/aria-snapshot/README.md
@@ -23,7 +23,7 @@ yarn add -D @cronn/aria-snapshot
 ## Writing Tests
 
 ```ts
-import { snapshotAria } from "@cronn/aria-snapshot";
+import { ariaSnapshot } from "@cronn/aria-snapshot";
 import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
 
 const expect = defineValidationFileExpect();
@@ -39,7 +39,7 @@ test("matches ARIA snapshot", async ({ page }) => {
     </main>
   `);
 
-  await expect(snapshotAria(page.getByRole("main"))).toMatchJsonFile();
+  await expect(ariaSnapshot(page.getByRole("main"))).toMatchJsonFile();
 });
 ```
 

--- a/packages/aria-snapshot/README.md
+++ b/packages/aria-snapshot/README.md
@@ -24,9 +24,9 @@ yarn add -D @cronn/aria-snapshot
 
 ```ts
 import { ariaSnapshot } from "@cronn/aria-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("matches ARIA snapshot", async ({ page }) => {
   await page.setContent(`

--- a/packages/aria-snapshot/data/test/validation/snapshot-function/combined_snapshot.json
+++ b/packages/aria-snapshot/data/test/validation/snapshot-function/combined_snapshot.json
@@ -1,0 +1,8 @@
+{
+  "sidenav": {
+    "navigation": "Sidenav"
+  },
+  "content": {
+    "main": "Main Content"
+  }
+}

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -36,11 +36,11 @@
     "test:unit:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@cronn/playwright-file-snapshots": "workspace:*",
     "yaml": "catalog:"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
-    "@cronn/playwright-file-snapshots": "workspace:*",
     "@cronn/shared-configs": "workspace:*",
     "@cronn/test-utils": "workspace:*",
     "@playwright/test": "catalog:",

--- a/packages/aria-snapshot/src/index.ts
+++ b/packages/aria-snapshot/src/index.ts
@@ -1,5 +1,5 @@
 export { defineAriaSnapshotMatchers } from "./matchers";
 
-export { snapshotAria } from "./snapshot";
+export { ariaSnapshot } from "./snapshot";
 
 export type { AriaSnapshotMatchers } from "./types";

--- a/packages/aria-snapshot/src/index.ts
+++ b/packages/aria-snapshot/src/index.ts
@@ -1,1 +1,5 @@
+export { defineAriaSnapshotMatchers } from "./matchers";
+
 export { snapshotAria } from "./snapshot";
+
+export type { AriaSnapshotMatchers } from "./types";

--- a/packages/aria-snapshot/src/matchers.ts
+++ b/packages/aria-snapshot/src/matchers.ts
@@ -1,0 +1,42 @@
+import type {
+  Expect,
+  ExpectMatcherState,
+  Locator,
+  MatcherReturnType,
+} from "@playwright/test";
+import { expect as baseExpect } from "@playwright/test";
+
+import type {
+  PlaywrightValidationFileMatcherConfig,
+  PlaywrightMatchJsonFileOptions,
+} from "@cronn/playwright-file-snapshots";
+import { defineJsonFileMatcher } from "@cronn/playwright-file-snapshots";
+
+import { snapshotAria } from "./snapshot";
+import type { AriaSnapshotMatchers } from "./types";
+
+/**
+ * Defines a custom Playwright expect instance with element snapshot matchers for validating DOM elements against stored snapshots.
+ *
+ * @param {PlaywrightValidationFileMatcherConfig} config - Configuration options for file matching behavior
+ * @return {Expect<AriaSnapshotMatchers>} An extended expect instance that includes matcher methods for ARIA snapshot validation.
+ */
+export function defineAriaSnapshotMatchers(
+  config: PlaywrightValidationFileMatcherConfig = {},
+): Expect<AriaSnapshotMatchers> {
+  async function toMatchAriaSnapshotFile(
+    this: ExpectMatcherState,
+    actual: Locator,
+    options: PlaywrightMatchJsonFileOptions = {},
+  ): Promise<MatcherReturnType> {
+    const toMatchJsonFile = defineJsonFileMatcher(
+      "toMatchAriaSnapshotFile",
+      config,
+    ).bind(this);
+    return await toMatchJsonFile(() => snapshotAria(actual), options);
+  }
+
+  return baseExpect.extend({
+    toMatchAriaSnapshotFile,
+  });
+}

--- a/packages/aria-snapshot/src/matchers.ts
+++ b/packages/aria-snapshot/src/matchers.ts
@@ -12,7 +12,7 @@ import type {
 } from "@cronn/playwright-file-snapshots";
 import { defineJsonFileMatcher } from "@cronn/playwright-file-snapshots";
 
-import { snapshotAria } from "./snapshot";
+import { ariaSnapshot } from "./snapshot";
 import type { AriaSnapshotMatchers } from "./types";
 
 /**
@@ -33,7 +33,7 @@ export function defineAriaSnapshotMatchers(
       "toMatchAriaSnapshotFile",
       config,
     ).bind(this);
-    return await toMatchJsonFile(() => snapshotAria(actual), options);
+    return await toMatchJsonFile(() => ariaSnapshot(actual), options);
   }
 
   return baseExpect.extend({

--- a/packages/aria-snapshot/src/snapshot.ts
+++ b/packages/aria-snapshot/src/snapshot.ts
@@ -17,11 +17,11 @@ import {
  *
  * @example
  * ```ts
- * await expect(snapshotAria(page.getByRole("main"))).toMatchJsonSnapshot();
+ * await expect(ariaSnapshot(page.getByRole("main"))).toMatchJsonFile();
  * ```
  * @param locator Locator for the element to snapshot
  */
-export async function snapshotAria(locator: Locator): Promise<unknown> {
+export async function ariaSnapshot(locator: Locator): Promise<unknown> {
   return await new AriaSnapshot().snapshot(locator);
 }
 

--- a/packages/aria-snapshot/src/test/fixtures.ts
+++ b/packages/aria-snapshot/src/test/fixtures.ts
@@ -1,17 +1,10 @@
-import type { Page } from "@playwright/test";
+import { mergeExpects } from "@playwright/test";
 
 import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
-import { setupSnapshotTest } from "@cronn/test-utils/playwright";
 
-import { snapshotAria } from "../snapshot";
+import { defineAriaSnapshotMatchers } from "../matchers";
 
-const expect = defineValidationFileExpect();
-
-export async function matchAriaSnapshot(
-  page: Page,
-  content: string,
-): Promise<void> {
-  const bodyLocator = await setupSnapshotTest(page, content);
-
-  await expect(snapshotAria(bodyLocator)).toMatchJsonFile();
-}
+export const expect = mergeExpects(
+  defineValidationFileExpect(),
+  defineAriaSnapshotMatchers(),
+);

--- a/packages/aria-snapshot/src/test/fixtures.ts
+++ b/packages/aria-snapshot/src/test/fixtures.ts
@@ -1,10 +1,10 @@
 import { mergeExpects } from "@playwright/test";
 
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
 import { defineAriaSnapshotMatchers } from "../matchers";
 
 export const expect = mergeExpects(
-  defineValidationFileExpect(),
+  defineFileSnapshotMatchers(),
   defineAriaSnapshotMatchers(),
 );

--- a/packages/aria-snapshot/src/types.ts
+++ b/packages/aria-snapshot/src/types.ts
@@ -1,0 +1,10 @@
+import type { Locator, MatcherReturnType } from "@playwright/test";
+
+import type { PlaywrightMatchJsonFileOptions } from "@cronn/playwright-file-snapshots";
+
+export interface AriaSnapshotMatchers {
+  toMatchAriaSnapshotFile: (
+    actual: Locator,
+    options?: PlaywrightMatchJsonFileOptions,
+  ) => Promise<MatcherReturnType>;
+}

--- a/packages/aria-snapshot/tests/normalizer.spec.ts
+++ b/packages/aria-snapshot/tests/normalizer.spec.ts
@@ -1,25 +1,27 @@
 import test from "@playwright/test";
 
-import { html } from "@cronn/test-utils/playwright";
+import { html, setupSnapshotTest } from "@cronn/test-utils/playwright";
 
-import { matchAriaSnapshot } from "../src/test/fixtures";
+import { expect } from "../src/test/fixtures";
 
 test("when snapshot contains an array, normalizes all items", async ({
   page,
 }) => {
-  await matchAriaSnapshot(
+  const bodyLocator = await setupSnapshotTest(
     page,
     html`
       <p>First Paragraph</p>
       <p>Second Paragraph</p>
     `,
   );
+
+  await expect(bodyLocator).toMatchAriaSnapshotFile();
 });
 
 test("when snapshot contains an object, normalizes all properties", async ({
   page,
 }) => {
-  await matchAriaSnapshot(
+  const bodyLocator = await setupSnapshotTest(
     page,
     html`
       <main>
@@ -28,12 +30,14 @@ test("when snapshot contains an object, normalizes all properties", async ({
       </main>
     `,
   );
+
+  await expect(bodyLocator).toMatchAriaSnapshotFile();
 });
 
 test("when array contains exactly one element, unwraps the element", async ({
   page,
 }) => {
-  await matchAriaSnapshot(
+  const bodyLocator = await setupSnapshotTest(
     page,
     html`
       <main>
@@ -41,17 +45,23 @@ test("when array contains exactly one element, unwraps the element", async ({
       </main>
     `,
   );
+
+  await expect(bodyLocator).toMatchAriaSnapshotFile();
 });
 
 test("replaces double quotes around text by single quotes", async ({
   page,
 }) => {
-  await matchAriaSnapshot(
+  const bodyLocator = await setupSnapshotTest(
     page,
     html`<input type="text" aria-label="Input Name" />`,
   );
+
+  await expect(bodyLocator).toMatchAriaSnapshotFile();
 });
 
 test("reduces text node to aggregated string", async ({ page }) => {
-  await matchAriaSnapshot(page, html`<p>Text</p>`);
+  const bodyLocator = await setupSnapshotTest(page, html`<p>Text</p>`);
+
+  await expect(bodyLocator).toMatchAriaSnapshotFile();
 });

--- a/packages/aria-snapshot/tests/snapshot-function.spec.ts
+++ b/packages/aria-snapshot/tests/snapshot-function.spec.ts
@@ -1,0 +1,21 @@
+import test from "@playwright/test";
+
+import { html, setupSnapshotTest } from "@cronn/test-utils/playwright";
+
+import { snapshotAria } from "../src/snapshot";
+import { expect } from "../src/test/fixtures";
+
+test("combined snapshot", async ({ page }) => {
+  const bodyLocator = await setupSnapshotTest(
+    page,
+    html`
+      <nav>Sidenav</nav>
+      <main>Main Content</main>
+    `,
+  );
+
+  await expect({
+    sidenav: await snapshotAria(bodyLocator.getByRole("navigation")),
+    content: await snapshotAria(bodyLocator.getByRole("main")),
+  }).toMatchJsonFile();
+});

--- a/packages/aria-snapshot/tests/snapshot-function.spec.ts
+++ b/packages/aria-snapshot/tests/snapshot-function.spec.ts
@@ -2,7 +2,7 @@ import test from "@playwright/test";
 
 import { html, setupSnapshotTest } from "@cronn/test-utils/playwright";
 
-import { snapshotAria } from "../src/snapshot";
+import { ariaSnapshot } from "../src/snapshot";
 import { expect } from "../src/test/fixtures";
 
 test("combined snapshot", async ({ page }) => {
@@ -15,7 +15,7 @@ test("combined snapshot", async ({ page }) => {
   );
 
   await expect({
-    sidenav: await snapshotAria(bodyLocator.getByRole("navigation")),
-    content: await snapshotAria(bodyLocator.getByRole("main")),
+    sidenav: await ariaSnapshot(bodyLocator.getByRole("navigation")),
+    content: await ariaSnapshot(bodyLocator.getByRole("main")),
   }).toMatchJsonFile();
 });

--- a/packages/docs/src/playwright/aria-snapshots.md
+++ b/packages/docs/src/playwright/aria-snapshots.md
@@ -24,16 +24,27 @@ yarn add -D @cronn/aria-snapshot
 
 :::
 
+## Define Custom Matchers
+
+Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
+
+```ts
+import { defineAriaSnapshotMatchers } from "@cronn/aria-snapshot";
+
+export const expect = defineAriaSnapshotMatchers();
+```
+
+The function takes the same options as `defineValidationFileExpect`. See [Configuration](/playwright/configuration) for a list of available configuration options.
+
 ## Writing Tests
 
 ```ts
-import { snapshotAria } from "@cronn/aria-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineAriaSnapshotMatchers } from "@cronn/aria-snapshot";
 
-const expect = defineValidationFileExpect();
+const expect = defineAriaSnapshotMatchers();
 
 test("matches ARIA snapshot", async ({ page }) => {
-  await expect(snapshotAria(page.getByRole("main"))).toMatchJsonFile();
+  await expect(page.getByRole("main")).toMatchAriaSnapshotFile();
 });
 ```
 
@@ -57,12 +68,15 @@ test("matches ARIA snapshot", async ({ page }) => {
 }
 ```
 
-## Composing Multiple ARIA Snapshots
+### Snapshot Function
 
-To compose multiple ARIA snapshots in a single JSON file, you can use an object structure:
+The `snapshotAria` function provides more flexibility than the `toMatchAriaSnapshotFile` matcher, because it returns the snapshot result as a JavaScript object instead of directly writing it to a file. This makes it suitable for composing custom assertions:
 
 ```ts
 import { snapshotAria } from "@cronn/aria-snapshot";
+import { defineValidationFileExpect } from "@cronn/playwright-file-matchers";
+
+const expect = defineValidationFileExpect();
 
 test("matches composed ARIA snapshots", async ({ page }) => {
   await expect({

--- a/packages/docs/src/playwright/aria-snapshots.md
+++ b/packages/docs/src/playwright/aria-snapshots.md
@@ -70,18 +70,18 @@ test("matches ARIA snapshot", async ({ page }) => {
 
 ### Snapshot Function
 
-The `snapshotAria` function provides more flexibility than the `toMatchAriaSnapshotFile` matcher, because it returns the snapshot result as a JavaScript object instead of directly writing it to a file. This makes it suitable for composing custom assertions:
+The `ariaSnapshot` function provides more flexibility than the `toMatchAriaSnapshotFile` matcher, because it returns the snapshot result as a JavaScript object instead of directly writing it to a file. This makes it suitable for composing custom assertions:
 
 ```ts
-import { snapshotAria } from "@cronn/aria-snapshot";
+import { ariaSnapshot } from "@cronn/aria-snapshot";
 import { defineValidationFileExpect } from "@cronn/playwright-file-matchers";
 
 const expect = defineValidationFileExpect();
 
 test("matches composed ARIA snapshots", async ({ page }) => {
   await expect({
-    nav: await snapshotAria(page.getByRole("navigation")),
-    main: await snapshotAria(page.getByRole("main")),
+    nav: await ariaSnapshot(page.getByRole("navigation")),
+    main: await ariaSnapshot(page.getByRole("main")),
   }).toMatchJsonFile();
 });
 ```

--- a/packages/docs/src/playwright/aria-snapshots.md
+++ b/packages/docs/src/playwright/aria-snapshots.md
@@ -34,7 +34,7 @@ import { defineAriaSnapshotMatchers } from "@cronn/aria-snapshot";
 export const expect = defineAriaSnapshotMatchers();
 ```
 
-The function takes the same options as `defineValidationFileExpect`. See [Configuration](/playwright/configuration) for a list of available configuration options.
+The function takes the same options as `defineFileSnapshotMatchers`. See [Configuration](/playwright/configuration) for a list of available configuration options.
 
 ## Writing Tests
 
@@ -74,9 +74,9 @@ The `ariaSnapshot` function provides more flexibility than the `toMatchAriaSnaps
 
 ```ts
 import { ariaSnapshot } from "@cronn/aria-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-matchers";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-matchers";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("matches composed ARIA snapshots", async ({ page }) => {
   await expect({

--- a/packages/docs/src/playwright/configuration.md
+++ b/packages/docs/src/playwright/configuration.md
@@ -3,9 +3,9 @@
 Configuration options can be passed when defining the file matchers:
 
 ```ts
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-const expect = defineValidationFileExpect({
+const expect = defineFileSnapshotMatchers({
   validationDir: "custom-validation",
   outputDir: "custom-output",
 });

--- a/packages/docs/src/playwright/element-snapshots/index.md
+++ b/packages/docs/src/playwright/element-snapshots/index.md
@@ -36,4 +36,4 @@ import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 export const expect = defineElementSnapshotMatchers();
 ```
 
-The function takes the same options as `defineValidationFileExpect`. See [Configuration](/playwright/configuration) for a list of available configuration options.
+The function takes the same options as `defineFileSnapshotMatchers`. See [Configuration](/playwright/configuration) for a list of available configuration options.

--- a/packages/docs/src/playwright/element-snapshots/index.md
+++ b/packages/docs/src/playwright/element-snapshots/index.md
@@ -31,9 +31,9 @@ yarn add -D @cronn/element-snapshot
 Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
 
 ```ts
-import { defineElementSnapshotExpect } from "@cronn/element-snapshot";
+import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 
-export const expect = defineElementSnapshotExpect();
+export const expect = defineElementSnapshotMatchers();
 ```
 
 The function takes the same options as `defineValidationFileExpect`. See [Configuration](/playwright/configuration) for a list of available configuration options.

--- a/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
+++ b/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
@@ -159,7 +159,7 @@ test("sorted table", async ({ page }) => {
 
 ## Snapshot Function
 
-The `markdownTableSnapshot` function provides more flexibility than the `toMatchMarkdownTableSnapshotFile` matcher, because it returns the snapshot result as a Markdown string for further processing instead of directly writing it to a file. This makes it suitable for custom assertions, transformations, or integrating the table representation into other parts of a test.
+The `markdownTableSnapshot` function provides more flexibility than the `toMatchMarkdownTableSnapshotFile` matcher, because it returns the snapshot result as a Markdown string instead of directly writing it to a file. This makes it suitable for composing custom assertions:
 
 ```ts
 import { markdownTableSnapshot } from "@cronn/element-snapshot";
@@ -183,7 +183,6 @@ test("processes markdown table snapshot result", async ({ page }) => {
   `);
 
   const markdownTable = await markdownTableSnapshot(page.getByRole("table"));
-  // Use the Markdown string for custom processing, assertions, or serialization
   expect(markdownTable).toContain("Alice");
 });
 ```

--- a/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
+++ b/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
@@ -13,10 +13,9 @@ Markdown table snapshots provide:
 ## Usage
 
 ```ts
-import { markdownTableSnapshot } from "@cronn/element-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 
-const expect = defineValidationFileExpect();
+const expect = defineElementSnapshotMatchers();
 
 test("matches table snapshot", async ({ page }) => {
   await expect(page.getByRole("table")).toMatchMarkdownTableSnapshotFile();

--- a/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
+++ b/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
@@ -77,7 +77,7 @@ await expect(page.getByRole("main")).toMatchSemanticSnapshotFile({
 
 ## Snapshot Function
 
-The `semanticSnapshot` function provides more flexibility than the `toMatchSemanticSnapshotFile` matcher, because it returns the snapshot result for further processing instead of directly writing it to a file. This makes it suitable for custom assertions, transformations, or integrating snapshot data into other parts of a test.
+The `semanticSnapshot` function provides more flexibility than the `toMatchSemanticSnapshotFile` matcher, because it returns the snapshot result as a JavaScript object instead of directly writing it to a file. This makes it suitable for composing custom assertions:
 
 ```ts
 import { semanticSnapshot } from "@cronn/element-snapshot";
@@ -92,7 +92,6 @@ test("combines semantic snapshot results", async ({ page }) => {
   `);
 
   const snapshot = await semanticSnapshot(page.locator("body"));
-  // Use the snapshot result for custom processing, assertions, or serialization
   expect({
     sidenav: await semanticSnapshot(page.getByRole("navigation")),
     content: await semanticSnapshot(page.getByRole("main")),

--- a/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
+++ b/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
@@ -3,10 +3,9 @@
 The `toMatchSemanticSnapshotFile` matcher provides a general-purpose snapshot covering the semantic structure of the target element. It includes all supported roles and attributes, providing a high test coverage. The format is optimized to be human-readable, but large and complex HTML structures will result in complex snapshots as well.
 
 ```ts
-import { semanticSnapshot } from "@cronn/element-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 
-const expect = defineValidationFileExpect();
+const expect = defineElementSnapshotMatchers();
 
 test("matches semantic snapshot", async ({ page }) => {
   await page.setContent(`
@@ -92,7 +91,7 @@ test("combines semantic snapshot results", async ({ page }) => {
   `);
 
   const snapshot = await semanticSnapshot(page.locator("body"));
-  expect({
+  await expect({
     sidenav: await semanticSnapshot(page.getByRole("navigation")),
     content: await semanticSnapshot(page.getByRole("main")),
   }).toMatchJsonFile();

--- a/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
+++ b/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
@@ -80,9 +80,9 @@ The `semanticSnapshot` function provides more flexibility than the `toMatchSeman
 
 ```ts
 import { semanticSnapshot } from "@cronn/element-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("combines semantic snapshot results", async ({ page }) => {
   await page.setContent(`

--- a/packages/docs/src/playwright/getting-started.md
+++ b/packages/docs/src/playwright/getting-started.md
@@ -25,9 +25,9 @@ yarn add -D @cronn/playwright-file-snapshots
 Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
 
 ```ts
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-export const expect = defineValidationFileExpect();
+export const expect = defineFileSnapshotMatchers();
 ```
 
 Then import your custom `expect` instead of Playwright's base `expect` in your tests:
@@ -48,9 +48,9 @@ If you are already using other custom matchers, you can merge them with the vali
 ```ts
 import { mergeExpects, mergeTests } from "@playwright/test";
 
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-const expect = mergeExpects(defineValidationFileExpect(), otherExpect);
+const expect = mergeExpects(defineFileSnapshotMatchers(), otherExpect);
 ```
 
 ## Configure `.gitignore`

--- a/packages/docs/src/playwright/index.md
+++ b/packages/docs/src/playwright/index.md
@@ -36,9 +36,9 @@ yarn add -D @cronn/playwright-file-snapshots
 Define the custom matchers (e.g. in `fixtures.ts`):
 
 ```ts
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-export const expect = defineValidationFileExpect();
+export const expect = defineFileSnapshotMatchers();
 ```
 
 Start writing tests:

--- a/packages/docs/src/playwright/index.md
+++ b/packages/docs/src/playwright/index.md
@@ -68,10 +68,10 @@ test("matches JSON file", async () => {
 ARIA Snapshots are a JSON-based adapter for Playwright's YAML-based ARIA Snapshots. They facilitate snapshot composition using a format natively supported by JavaScript.
 
 ```ts
-import { snapshotAria } from "@cronn/aria-snapshot";
+import { ariaSnapshot } from "@cronn/aria-snapshot";
 
 test("matches ARIA snapshot", async ({ page }) => {
-  await expect(snapshotAria(page.getByRole("main"))).toMatchJsonFile();
+  await expect(ariaSnapshot(page.getByRole("main"))).toMatchJsonFile();
 });
 ```
 

--- a/packages/docs/src/playwright/writing-tests.md
+++ b/packages/docs/src/playwright/writing-tests.md
@@ -120,7 +120,7 @@ test("match values using soft assertions", async () => {
 ### Enabling Soft Assertions for All Matchers
 
 ```ts
-export const expect = defineValidationFileExpect().configure({
+export const expect = defineFileSnapshotMatchers().configure({
   soft: true,
 });
 ```

--- a/packages/docs/src/vitest/configuration.md
+++ b/packages/docs/src/vitest/configuration.md
@@ -3,7 +3,7 @@
 Configuration options can be passed when registering the file matchers in the setup file:
 
 ```ts
-registerValidationFileMatchers({
+registerFileSnapshotMatchers({
   testDir: "src",
 });
 ```

--- a/packages/docs/src/vitest/getting-started.md
+++ b/packages/docs/src/vitest/getting-started.md
@@ -25,9 +25,9 @@ yarn add -D @cronn/vitest-file-snapshots
 Import the custom matchers in your `vitest-setup.ts`:
 
 ```ts
-import { registerValidationFileMatchers } from "@cronn/vitest-file-snapshots/register";
+import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
-registerValidationFileMatchers();
+registerFileSnapshotMatchers();
 ```
 
 ### Create Setup File

--- a/packages/docs/src/vitest/index.md
+++ b/packages/docs/src/vitest/index.md
@@ -38,9 +38,9 @@ yarn add -D @cronn/vitest-file-snapshots
 Register the custom matchers in your `vitest-setup.ts`:
 
 ```ts
-import { registerValidationFileMatchers } from "@cronn/vitest-file-snapshots/register";
+import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
-registerValidationFileMatchers();
+registerFileSnapshotMatchers();
 ```
 
 Start writing tests:

--- a/packages/element-snapshot/README.md
+++ b/packages/element-snapshot/README.md
@@ -27,9 +27,9 @@ yarn add -D @cronn/element-snapshot
 
 ```ts
 import { semanticSnapshot } from "@cronn/element-snapshot";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("matches element snapshot", async ({ page }) => {
   await page.setContent(`

--- a/packages/element-snapshot/src/index.ts
+++ b/packages/element-snapshot/src/index.ts
@@ -1,4 +1,4 @@
-export { defineElementSnapshotExpect } from "./playwright/matchers";
+export { defineElementSnapshotMatchers } from "./playwright/matchers";
 
 export type { ElementRole } from "./types/role";
 export type { ElementSnapshot, NodeRole, NodeSnapshot } from "./types/snapshot";

--- a/packages/element-snapshot/src/playwright/matchers.ts
+++ b/packages/element-snapshot/src/playwright/matchers.ts
@@ -27,7 +27,7 @@ import { semanticSnapshot } from "./snapshot";
  * @param {PlaywrightValidationFileMatcherConfig} config - Configuration options for file matching behavior
  * @return {Expect<ElementSnapshotMatchers>} An extended expect instance that includes matcher methods for element snapshot validation.
  */
-export function defineElementSnapshotExpect(
+export function defineElementSnapshotMatchers(
   config: PlaywrightValidationFileMatcherConfig = {},
 ): Expect<ElementSnapshotMatchers> {
   async function toMatchSemanticSnapshotFile(

--- a/packages/element-snapshot/src/test/fixtures.ts
+++ b/packages/element-snapshot/src/test/fixtures.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { mergeExpects } from "@playwright/test";
 
 import type { PlaywrightValidationFileMatcherConfig } from "@cronn/playwright-file-snapshots";
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 import { setupSnapshotTest } from "@cronn/test-utils/playwright";
 
 import { defineElementSnapshotMatchers } from "../playwright/matchers";
@@ -14,7 +14,7 @@ const config: PlaywrightValidationFileMatcherConfig = {
 };
 
 export const expect = mergeExpects(
-  defineValidationFileExpect(config),
+  defineFileSnapshotMatchers(config),
   defineElementSnapshotMatchers(config),
 );
 

--- a/packages/element-snapshot/src/test/fixtures.ts
+++ b/packages/element-snapshot/src/test/fixtures.ts
@@ -5,7 +5,7 @@ import type { PlaywrightValidationFileMatcherConfig } from "@cronn/playwright-fi
 import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
 import { setupSnapshotTest } from "@cronn/test-utils/playwright";
 
-import { defineElementSnapshotExpect } from "../playwright/matchers";
+import { defineElementSnapshotMatchers } from "../playwright/matchers";
 import { rawSnapshot } from "../playwright/snapshot";
 
 const config: PlaywrightValidationFileMatcherConfig = {
@@ -15,7 +15,7 @@ const config: PlaywrightValidationFileMatcherConfig = {
 
 export const expect = mergeExpects(
   defineValidationFileExpect(config),
-  defineElementSnapshotExpect(config),
+  defineElementSnapshotMatchers(config),
 );
 
 export async function matchRawElementSnapshot(

--- a/packages/element-snapshot/vitest-setup.ts
+++ b/packages/element-snapshot/vitest-setup.ts
@@ -1,6 +1,6 @@
-import { registerValidationFileMatchers } from "@cronn/vitest-file-snapshots/register";
+import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
-registerValidationFileMatchers({
+registerFileSnapshotMatchers({
   testDir: "src",
   validationDir: "data/unit-test/validation",
   outputDir: "data/unit-test/output",

--- a/packages/playwright-file-snapshots/README.md
+++ b/packages/playwright-file-snapshots/README.md
@@ -25,9 +25,9 @@ yarn add -D @cronn/playwright-file-snapshots
 Define a reusable `expect` export (e.g. in `fixtures.ts`):
 
 ```ts
-import { defineValidationFileExpect } from "@cronn/playwright-file-snapshots";
+import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
-export const expect = defineValidationFileExpect();
+export const expect = defineFileSnapshotMatchers();
 ```
 
 Add the output directory to your `.gitignore`:

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -1,8 +1,8 @@
 export {
   defineJsonFileMatcher,
   defineTextFileMatcher,
-  defineValidationFileExpect,
-} from "./matchers/define-expect";
+  defineFileSnapshotMatchers,
+} from "./matchers/define-matchers";
 export type {
   PlaywrightMatchValidationFileOptions,
   PlaywrightMatchTextFileOptions,

--- a/packages/playwright-file-snapshots/src/matchers/define-matchers.ts
+++ b/packages/playwright-file-snapshots/src/matchers/define-matchers.ts
@@ -24,7 +24,7 @@ import type {
  * @param {PlaywrightValidationFileMatcherConfig} config - Configuration object for customizing the behavior of file validation matchers, such as file paths, update strategies, and comparison options. Defaults to an empty object if not provided.
  * @return {Expect<PlaywrightValidationFileMatchers>} An extended expect object that includes toMatchJsonFile and toMatchTextFile matcher methods for validating content against stored files.
  */
-export function defineValidationFileExpect(
+export function defineFileSnapshotMatchers(
   config: PlaywrightValidationFileMatcherConfig = {},
 ): Expect<PlaywrightValidationFileMatchers> {
   return baseExpect.extend({

--- a/packages/playwright-file-snapshots/tests/json-file-matcher.spec.ts
+++ b/packages/playwright-file-snapshots/tests/json-file-matcher.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { defineValidationFileExpect } from "../src";
+import { defineFileSnapshotMatchers } from "../src";
 import {
   SnapshotInstrumentation,
   assertSnapshotIntervals,
@@ -10,7 +10,7 @@ import {
   testFilePathResolver,
 } from "../src/utils/test";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("matches value with JSON file", async () => {
   await expect({ key: "value" }).toMatchJsonFile();
@@ -62,7 +62,7 @@ test("applies custom file path resolver", async () => {
 test("applies update delay", { tag: tags.updateAll }, async () => {
   runOnlyWhenSnapshotUpdatesAreEnabled();
 
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     ...temporarySnapshotDirs(),
     updateDelay: 100,
   });

--- a/packages/playwright-file-snapshots/tests/matcher-config.spec.ts
+++ b/packages/playwright-file-snapshots/tests/matcher-config.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { defineValidationFileExpect } from "../src";
+import { defineFileSnapshotMatchers } from "../src";
 import {
   SnapshotInstrumentation,
   assertSnapshotIntervals,
@@ -11,7 +11,7 @@ import {
 } from "../src/utils/test";
 
 test("stores snapshots in custom directories", async () => {
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     validationDir: "custom-data/validation",
     outputDir: "custom-data/output",
   });
@@ -20,7 +20,7 @@ test("stores snapshots in custom directories", async () => {
 });
 
 test("applies custom file path resolver", async () => {
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     resolveFilePath: testFilePathResolver,
   });
 
@@ -28,7 +28,7 @@ test("applies custom file path resolver", async () => {
 });
 
 test("when snapshot does not match, hard assertion throws error", async () => {
-  const testExpect = defineValidationFileExpect();
+  const testExpect = defineFileSnapshotMatchers();
 
   await expect(() =>
     testExpect("changed value").toMatchJsonFile(),
@@ -38,14 +38,14 @@ test("when snapshot does not match, hard assertion throws error", async () => {
 test.fail(
   "when snapshot does not match, soft assertion fails test",
   async () => {
-    const testExpect = defineValidationFileExpect();
+    const testExpect = defineFileSnapshotMatchers();
 
     await testExpect.soft("changed value").toMatchJsonFile();
   },
 );
 
 test("applies indentSize to JSON file snapshots", async () => {
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     indentSize: 4,
   });
 
@@ -53,7 +53,7 @@ test("applies indentSize to JSON file snapshots", async () => {
 });
 
 test("ignores indentSize in text file snapshots", async () => {
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     indentSize: 4,
   });
 
@@ -63,7 +63,7 @@ test("ignores indentSize in text file snapshots", async () => {
 test("applies update delay", { tag: tags.updateAll }, async () => {
   runOnlyWhenSnapshotUpdatesAreEnabled();
 
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     ...temporarySnapshotDirs(),
     updateDelay: 100,
   });

--- a/packages/playwright-file-snapshots/tests/repeatable-snapshot.spec.ts
+++ b/packages/playwright-file-snapshots/tests/repeatable-snapshot.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { defineValidationFileExpect } from "../src";
+import { defineFileSnapshotMatchers } from "../src";
 import {
   SnapshotInstrumentation,
   assertSnapshotIntervals,
@@ -10,7 +10,7 @@ import {
 } from "../src/utils/test";
 
 test("when validation file is missing, waits for delay before creating snapshot", async () => {
-  const testExpect = defineValidationFileExpect(temporarySnapshotDirs());
+  const testExpect = defineFileSnapshotMatchers(temporarySnapshotDirs());
 
   const instrumentation = new SnapshotInstrumentation();
   await expect(() =>
@@ -29,7 +29,7 @@ test(
   async () => {
     runOnlyWhenSnapshotUpdatesAreEnabled();
 
-    const testExpect = defineValidationFileExpect(temporarySnapshotDirs());
+    const testExpect = defineFileSnapshotMatchers(temporarySnapshotDirs());
 
     const instrumentation = new SnapshotInstrumentation();
     await expect(() =>
@@ -47,7 +47,7 @@ test(
 );
 
 test("when validation file exists, repeats failing snapshot until it matches", async () => {
-  const testExpect = defineValidationFileExpect();
+  const testExpect = defineFileSnapshotMatchers();
 
   const instrumentation = new SnapshotInstrumentation();
   await testExpect(() => {
@@ -63,7 +63,7 @@ test("when validation file exists, repeats failing snapshot until it matches", a
 });
 
 test("when validation file exists, repeats failing snapshot until timeout", async () => {
-  const testExpect = defineValidationFileExpect().configure({ timeout: 2_000 });
+  const testExpect = defineFileSnapshotMatchers().configure({ timeout: 2_000 });
 
   const instrumentation = new SnapshotInstrumentation();
   await testExpect(() =>
@@ -77,7 +77,7 @@ test("when validation file exists, repeats failing snapshot until timeout", asyn
 });
 
 test("applies custom timeout", async () => {
-  const testExpect = defineValidationFileExpect();
+  const testExpect = defineFileSnapshotMatchers();
 
   const instrumentation = new SnapshotInstrumentation();
   await testExpect(async () =>
@@ -91,7 +91,7 @@ test("applies custom timeout", async () => {
 });
 
 test("when trying to snapshot a function with parameters, throws error", async () => {
-  const testExpect = defineValidationFileExpect();
+  const testExpect = defineFileSnapshotMatchers();
 
   await expect(() =>
     testExpect((value: unknown) => value).toMatchJsonFile(),

--- a/packages/playwright-file-snapshots/tests/test-dir/file-path.spec.ts
+++ b/packages/playwright-file-snapshots/tests/test-dir/file-path.spec.ts
@@ -1,8 +1,8 @@
 import { test } from "@playwright/test";
 
-import { defineValidationFileExpect } from "../../src";
+import { defineFileSnapshotMatchers } from "../../src";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test.describe("describe title", () => {
   test("test title", async () => {

--- a/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
+++ b/packages/playwright-file-snapshots/tests/text-file-matcher.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { defineValidationFileExpect } from "../src";
+import { defineFileSnapshotMatchers } from "../src";
 import {
   SnapshotInstrumentation,
   assertSnapshotIntervals,
@@ -10,7 +10,7 @@ import {
   testFilePathResolver,
 } from "../src/utils/test";
 
-const expect = defineValidationFileExpect();
+const expect = defineFileSnapshotMatchers();
 
 test("matches value with text file", async () => {
   await expect("value").toMatchTextFile();
@@ -56,7 +56,7 @@ test("applies custom file extension", async () => {
 test("applies update delay", { tag: tags.updateAll }, async () => {
   runOnlyWhenSnapshotUpdatesAreEnabled();
 
-  const testExpect = defineValidationFileExpect({
+  const testExpect = defineFileSnapshotMatchers({
     ...temporarySnapshotDirs(),
     updateDelay: 100,
   });

--- a/packages/playwright-file-snapshots/tests/update-snapshot.spec.ts
+++ b/packages/playwright-file-snapshots/tests/update-snapshot.spec.ts
@@ -2,7 +2,7 @@ import { type Expect, expect, test } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 
-import { defineValidationFileExpect } from "../src";
+import { defineFileSnapshotMatchers } from "../src";
 import type { PlaywrightValidationFileMatchers } from "../src/matchers/types";
 import { resolvePackageRootDir } from "../src/utils/file";
 import {
@@ -20,7 +20,7 @@ test("when updateSnapshots is 'missing', creates missing validation file", async
   runOnlyWhenUpdateSnapshotsIs("missing");
 
   const snapshotDirs = temporarySnapshotDirs();
-  const testExpect = defineValidationFileExpect(snapshotDirs);
+  const testExpect = defineFileSnapshotMatchers(snapshotDirs);
 
   await matchInitialValueWithError(testExpect);
 
@@ -33,7 +33,7 @@ test("when updateSnapshots is 'missing', does not update changed validation file
   runOnlyWhenUpdateSnapshotsIs("missing");
 
   const snapshotDirs = temporarySnapshotDirs();
-  const testExpect = defineValidationFileExpect(snapshotDirs);
+  const testExpect = defineFileSnapshotMatchers(snapshotDirs);
 
   await matchInitialValueWithError(testExpect);
   await matchChangedValueWithError(testExpect);
@@ -61,7 +61,7 @@ for (const { updateType, tag } of updateTestCases) {
       runOnlyWhenUpdateSnapshotsIs(updateType);
 
       const snapshotDirs = temporarySnapshotDirs();
-      const testExpect = defineValidationFileExpect(snapshotDirs);
+      const testExpect = defineFileSnapshotMatchers(snapshotDirs);
 
       await matchInitialValueWithError(testExpect);
 
@@ -78,7 +78,7 @@ for (const { updateType, tag } of updateTestCases) {
       runOnlyWhenSnapshotUpdatesAreEnabled();
 
       const snapshotDirs = temporarySnapshotDirs();
-      const testExpect = defineValidationFileExpect(snapshotDirs);
+      const testExpect = defineFileSnapshotMatchers(snapshotDirs);
 
       await matchInitialValueWithError(testExpect);
       await matchChangedValueWithError(testExpect);
@@ -96,7 +96,7 @@ test(
   async () => {
     runOnlyWhenUpdateSnapshotsIs("none");
 
-    const testExpect = defineValidationFileExpect();
+    const testExpect = defineFileSnapshotMatchers();
 
     await matchInitialValueWithError(testExpect);
 
@@ -111,7 +111,7 @@ test(
   async () => {
     runOnlyWhenUpdateSnapshotsIs("none");
 
-    const testExpect = defineValidationFileExpect();
+    const testExpect = defineFileSnapshotMatchers();
 
     await matchChangedValueWithError(testExpect);
 

--- a/packages/vitest-file-snapshots/README.md
+++ b/packages/vitest-file-snapshots/README.md
@@ -25,9 +25,9 @@ yarn add -D @cronn/vitest-file-snapshots
 Register the custom matchers in your `vitest-setup.ts`:
 
 ```ts
-import { registerValidationFileMatchers } from "@cronn/vitest-file-snapshots/register";
+import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
-registerValidationFileMatchers();
+registerFileSnapshotMatchers();
 ```
 
 Add the setup file to your `vitest.config.ts`:

--- a/packages/vitest-file-snapshots/src/__tests__/json-file-matcher.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/json-file-matcher.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, expect, test } from "vitest";
 
-import { registerValidationFileMatchers } from "../matchers/register-matchers";
+import { registerFileSnapshotMatchers } from "../matchers/register-matchers";
 import { testFilePathResolver } from "../utils/test";
 
-beforeEach(() => registerValidationFileMatchers());
+beforeEach(() => registerFileSnapshotMatchers());
 
 test("matches value with JSON file", () => {
   expect({

--- a/packages/vitest-file-snapshots/src/__tests__/markdown-table-file-matcher.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/markdown-table-file-matcher.test.ts
@@ -3,10 +3,10 @@ import { beforeEach, expect, test } from "vitest";
 import type { TableCell } from "@cronn/lib-file-snapshots";
 import { Table } from "@cronn/lib-file-snapshots";
 
-import { registerValidationFileMatchers } from "../matchers/register-matchers";
+import { registerFileSnapshotMatchers } from "../matchers/register-matchers";
 import { testFilePathResolver } from "../utils/test";
 
-beforeEach(() => registerValidationFileMatchers());
+beforeEach(() => registerFileSnapshotMatchers());
 
 test("matches table with Markdown file", () => {
   expect(

--- a/packages/vitest-file-snapshots/src/__tests__/matcher-configuration.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/matcher-configuration.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "vitest";
 
-import { registerValidationFileMatchers } from "../matchers/register-matchers";
+import { registerFileSnapshotMatchers } from "../matchers/register-matchers";
 import { testFilePathResolver } from "../utils/test";
 
 test("resolves test path relative to testDir", () => {
-  registerValidationFileMatchers({
+  registerFileSnapshotMatchers({
     testDir: "src",
   });
 
@@ -12,7 +12,7 @@ test("resolves test path relative to testDir", () => {
 });
 
 test("stores snapshots in custom directories", () => {
-  registerValidationFileMatchers({
+  registerFileSnapshotMatchers({
     validationDir: "custom-data/validation",
     outputDir: "custom-data/output",
   });
@@ -21,7 +21,7 @@ test("stores snapshots in custom directories", () => {
 });
 
 test("applies indentSize to JSON file snapshots", () => {
-  registerValidationFileMatchers({
+  registerFileSnapshotMatchers({
     indentSize: 4,
   });
 
@@ -29,7 +29,7 @@ test("applies indentSize to JSON file snapshots", () => {
 });
 
 test("ignores indentSize in text file snapshots", () => {
-  registerValidationFileMatchers({
+  registerFileSnapshotMatchers({
     indentSize: 4,
   });
 
@@ -37,7 +37,7 @@ test("ignores indentSize in text file snapshots", () => {
 });
 
 test("applies custom file path resolver", () => {
-  registerValidationFileMatchers({
+  registerFileSnapshotMatchers({
     resolveFilePath: testFilePathResolver,
   });
 

--- a/packages/vitest-file-snapshots/src/__tests__/text-file-matcher.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/text-file-matcher.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, expect, test } from "vitest";
 
-import { registerValidationFileMatchers } from "../matchers/register-matchers";
+import { registerFileSnapshotMatchers } from "../matchers/register-matchers";
 import { testFilePathResolver } from "../utils/test";
 
-beforeEach(() => registerValidationFileMatchers());
+beforeEach(() => registerFileSnapshotMatchers());
 
 test("matches value with text file", () => {
   expect("value").toMatchTextFile();

--- a/packages/vitest-file-snapshots/src/__tests__/update-snapshot.test.ts
+++ b/packages/vitest-file-snapshots/src/__tests__/update-snapshot.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { TestRunner, expect, test } from "vitest";
 
-import { registerValidationFileMatchers } from "../register";
+import { registerFileSnapshotMatchers } from "../register";
 import {
   resolvePackageRootDir,
   tags,
@@ -17,7 +17,7 @@ test.runIf(TestRunner.matchesTags([tags.updateNew]))(
   { tags: [tags.updateNew] },
   () => {
     const snapshotDirs = temporarySnapshotDirs();
-    registerValidationFileMatchers(snapshotDirs);
+    registerFileSnapshotMatchers(snapshotDirs);
 
     matchInitialValueWithError();
 
@@ -32,7 +32,7 @@ test.runIf(TestRunner.matchesTags([tags.updateNew]))(
   { tags: [tags.updateNew] },
   () => {
     const snapshotDirs = temporarySnapshotDirs();
-    registerValidationFileMatchers(snapshotDirs);
+    registerFileSnapshotMatchers(snapshotDirs);
 
     matchInitialValueWithError();
     matchChangedValueWithError();
@@ -48,7 +48,7 @@ test.runIf(TestRunner.matchesTags([tags.updateAll]))(
   { tags: [tags.updateAll] },
   () => {
     const snapshotDirs = temporarySnapshotDirs();
-    registerValidationFileMatchers(snapshotDirs);
+    registerFileSnapshotMatchers(snapshotDirs);
 
     matchInitialValueWithError();
 
@@ -63,7 +63,7 @@ test.runIf(TestRunner.matchesTags([tags.updateAll]))(
   { tags: [tags.updateAll] },
   () => {
     const snapshotDirs = temporarySnapshotDirs();
-    registerValidationFileMatchers(snapshotDirs);
+    registerFileSnapshotMatchers(snapshotDirs);
 
     matchInitialValueWithError();
     matchChangedValueWithError();
@@ -79,7 +79,7 @@ test.runIf(TestRunner.matchesTags([tags.updateNone]))(
   { tags: [tags.updateNone] },
   () => {
     const snapshotDirs = temporarySnapshotDirs();
-    registerValidationFileMatchers(snapshotDirs);
+    registerFileSnapshotMatchers(snapshotDirs);
 
     matchInitialValueWithError();
 
@@ -91,7 +91,7 @@ test.runIf(TestRunner.matchesTags([tags.updateNone]))(
   "when updateSnapshots is 'none', does not update changed validation file",
   { tags: [tags.updateNone] },
   async () => {
-    registerValidationFileMatchers();
+    registerFileSnapshotMatchers();
 
     matchChangedValueWithError();
 

--- a/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
+++ b/packages/vitest-file-snapshots/src/matchers/register-matchers.ts
@@ -17,7 +17,7 @@ import type {
   VitestValidationFileMatchers,
 } from "./types";
 
-export function registerValidationFileMatchers(
+export function registerFileSnapshotMatchers(
   config: VitestValidationFileMatcherConfig = {},
 ): void {
   const { indentSize, ...snapshotConfig } = config;

--- a/packages/vitest-file-snapshots/src/register.ts
+++ b/packages/vitest-file-snapshots/src/register.ts
@@ -5,4 +5,4 @@ declare module "vitest" {
   interface Matchers<T = any> extends VitestValidationFileMatchers<T> {}
 }
 
-export { registerValidationFileMatchers } from "./matchers/register-matchers";
+export { registerFileSnapshotMatchers } from "./matchers/register-matchers";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
 
   packages/aria-snapshot:
     dependencies:
+      '@cronn/playwright-file-snapshots':
+        specifier: workspace:*
+        version: link:../playwright-file-snapshots
       yaml:
         specifier: 'catalog:'
         version: 2.8.3
@@ -329,9 +332,6 @@ importers:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
         version: 0.18.2
-      '@cronn/playwright-file-snapshots':
-        specifier: workspace:*
-        version: link:../playwright-file-snapshots
       '@cronn/shared-configs':
         specifier: workspace:*
         version: link:../shared-configs


### PR DESCRIPTION
This PR provides a `toMatchAriaSnapshotFile` matcher for the **aria-snapshot** package to enable using a familiar matcher API and internalize snapshot retries.

As part of the APIs for the definition of custom matchers were streamlined, eliminating existing inconsistencies.