### PR TITLE
fix(playwright-file-snapshots): Filter expect steps with complex locator expressions

### DIFF
--- a/.changeset/dark-dogs-lead.md
+++ b/.changeset/dark-dogs-lead.md
@@ -1,0 +1,8 @@
+---
+"@cronn/playwright-file-snapshots": patch
+"@cronn/element-snapshot": patch
+"@cronn/aria-snapshot": patch
+---
+
+Filter `expect` steps with complex locator expressions.
+Match any locator expression instead of only simple single-method locators, enabling support for chained locator methods like `locator('body').getByRole('textbox', { name: 'my-input' })`.

--- a/packages/playwright-file-snapshots/src/__tests__/matcher-utils.test.ts
+++ b/packages/playwright-file-snapshots/src/__tests__/matcher-utils.test.ts
@@ -119,6 +119,7 @@ describe("parseTitlePath", () => {
         "step title",
         'Expect "toThrowError"',
         'Expect "soft toMatchJsonFile"',
+        `Expect "toMatchLocator" locator('body').getByRole('textbox', { name: 'my-input' })`,
         "Match validation file",
       ]),
     ).toStrictEqual(["test title", "step title"]);

--- a/packages/playwright-file-snapshots/src/matchers/utils.ts
+++ b/packages/playwright-file-snapshots/src/matchers/utils.ts
@@ -60,8 +60,7 @@ export function parseTestPath(testPath: string): string {
 
 export const MATCHER_STEP_TITLE = "Match validation file";
 
-const EXPECT_STEP_REGEXP =
-  /^Expect "(?<matcher>[\w ]+)"(?<locator> \w+\('\w+'\))?$/;
+const EXPECT_STEP_REGEXP = /^Expect "(?<matcher>[\w ]+)"(?<locator> .+)?$/;
 
 export function parseTitlePath(titlePath: Array<string>): Array<string> {
   return titlePath.filter(isUserDefinedTitle);


### PR DESCRIPTION
Match any locator expression instead of only simple single-method locators, enabling support for chained locator methods like `locator('body').getByRole('textbox', { name: 'my-input' })`.