### PR TITLE
docs: Use code block labels for file names

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from "vitepress";
+import {
+  groupIconMdPlugin,
+  groupIconVitePlugin,
+} from "vitepress-plugin-group-icons";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -9,6 +13,15 @@ export default defineConfig({
   srcDir: "src",
   cleanUrls: true,
   lastUpdated: true,
+
+  markdown: {
+    config(md) {
+      md.use(groupIconMdPlugin);
+    },
+  },
+  vite: {
+    plugins: [groupIconVitePlugin()],
+  },
 
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import "virtual:group-icons.css";
+import Theme from "vitepress/theme";
+
+export default Theme;

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -29,7 +29,8 @@
     "oxc-minify": "catalog:",
     "rimraf": "catalog:",
     "typescript-eslint": "catalog:",
-    "vitepress": "catalog:"
+    "vitepress": "catalog:",
+    "vitepress-plugin-group-icons": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/docs/src/playwright/aria-snapshots.md
+++ b/packages/docs/src/playwright/aria-snapshots.md
@@ -28,7 +28,7 @@ yarn add -D @cronn/aria-snapshot
 
 Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
 
-```ts
+```ts [fixtures.ts]
 import { defineAriaSnapshotMatchers } from "@cronn/aria-snapshot";
 
 export const expect = defineAriaSnapshotMatchers();
@@ -58,9 +58,9 @@ test("matches ARIA snapshot", async ({ page }) => {
 });
 ```
 
-**Output (`̀matches_ARIA_snapshot.json`):**
+**Output:**
 
-```json
+```json [matches_ARIA_snapshot.json]
 {
   "main": [
     "heading 'List' [level=1]",

--- a/packages/docs/src/playwright/configuration.md
+++ b/packages/docs/src/playwright/configuration.md
@@ -2,7 +2,7 @@
 
 Configuration options can be passed when defining the file matchers:
 
-```ts
+```ts [fixtures.ts]
 import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
 const expect = defineFileSnapshotMatchers({

--- a/packages/docs/src/playwright/element-snapshots/index.md
+++ b/packages/docs/src/playwright/element-snapshots/index.md
@@ -30,7 +30,7 @@ yarn add -D @cronn/element-snapshot
 
 Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
 
-```ts
+```ts [fixtures.ts]
 import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 
 export const expect = defineElementSnapshotMatchers();

--- a/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
+++ b/packages/docs/src/playwright/element-snapshots/markdown-table-snapshot.md
@@ -74,7 +74,7 @@ test("employee table", async ({ page }) => {
 
 **Output:**
 
-```md
+```md [employee_table.md]
 | Employee      | Department  | Salary  |
 | ------------- | ----------- | ------- |
 | Alice Johnson | Engineering | $95,000 |
@@ -111,7 +111,7 @@ test("product grid", async ({ page }) => {
 
 **Output:**
 
-```md
+```md [product_grid.md]
 | Product | Price | Stock |
 | ------- | ----- | ----- |
 | Laptop  | $999  | 15    |
@@ -149,7 +149,7 @@ test("sorted table", async ({ page }) => {
 
 **Output:**
 
-```md
+```md [sorted_table.md]
 | Name ⯆ | Score |
 | ------ | ----- |
 | Alice  | 95    |

--- a/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
+++ b/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
@@ -22,9 +22,9 @@ test("matches semantic snapshot", async ({ page }) => {
 });
 ```
 
-**Output (`matches_semantic_snapshot.json`):**
+**Output:**
 
-```json
+```json [matches_semantic_snapshot.json]
 {
   "main": [
     {

--- a/packages/docs/src/playwright/file-matchers/to-match-json-file.md
+++ b/packages/docs/src/playwright/file-matchers/to-match-json-file.md
@@ -16,9 +16,9 @@ test("matches page title ultimately", async () => {
 });
 ```
 
-**Output (`matches_page_title.json`):**
+**Output:**
 
-```json
+```json [matches_page_title.json]
 {
   "title": "Page Title"
 }
@@ -50,9 +50,9 @@ test("includes undefined properties", async () => {
 });
 ```
 
-**Output (`includes_undefined_properties.json`):**
+**Output:**
 
-```json
+```json [includes_undefined_properties.json]
 {
   "name": "Alice",
   "age": {

--- a/packages/docs/src/playwright/file-matchers/to-match-text-file.md
+++ b/packages/docs/src/playwright/file-matchers/to-match-text-file.md
@@ -14,9 +14,9 @@ test("matches page title", async () => {
 });
 ```
 
-**Output (`matches_page_title.txt`):**
+**Output:**
 
-```
+```[matches_page_title.txt]
 Page Title
 ```
 
@@ -46,9 +46,9 @@ test("matches HTML snapshot", async ({ page }) => {
 });
 ```
 
-**Output (`matches_HTML_snapshot.html`):**
+**Output:**
 
-```html
+```html [matches_HTML_snapshot.html]
 <main>Hello World</main>
 ```
 

--- a/packages/docs/src/playwright/getting-started.md
+++ b/packages/docs/src/playwright/getting-started.md
@@ -24,7 +24,7 @@ yarn add -D @cronn/playwright-file-snapshots
 
 Define the Custom Matchers as a reusable export (e.g. in `fixtures.ts`):
 
-```ts
+```ts [fixtures.ts]
 import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
 export const expect = defineFileSnapshotMatchers();
@@ -45,7 +45,7 @@ test("matches JSON file", async () => {
 
 If you are already using other custom matchers, you can merge them with the validation file matchers:
 
-```ts
+```ts [fixtures.ts]
 import { mergeExpects, mergeTests } from "@playwright/test";
 
 import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
@@ -57,7 +57,7 @@ const expect = mergeExpects(defineFileSnapshotMatchers(), otherExpect);
 
 All file snapshots are generated to `/data/test`. The golden masters will be stored in `/data/test/validation`, which should be under version control. The file snapshots generated for test runs will be stored under `/data/test/output` and should be ignored:
 
-```
+```[.gitignore]
 # file snapshots
 /data/test/output
 ```

--- a/packages/docs/src/playwright/index.md
+++ b/packages/docs/src/playwright/index.md
@@ -68,10 +68,12 @@ test("matches JSON file", async () => {
 ARIA Snapshots are a JSON-based adapter for Playwright's YAML-based ARIA Snapshots. They facilitate snapshot composition using a format natively supported by JavaScript.
 
 ```ts
-import { ariaSnapshot } from "@cronn/aria-snapshot";
+import { defineAriaSnapshotMatchers } from "@cronn/aria-snapshot";
+
+const expect = defineAriaSnapshotMatchers();
 
 test("matches ARIA snapshot", async ({ page }) => {
-  await expect(ariaSnapshot(page.getByRole("main"))).toMatchJsonFile();
+  await expect(page.getByRole("main")).toMatchAriaSnapshotFile();
 });
 ```
 
@@ -102,16 +104,18 @@ test("matches ARIA snapshot", async ({ page }) => {
 Element Snapshots are an alternative to ARIA Snapshots, providing a higher coverage of HTML and ARIA attributes as well as the ability to implement custom snapshots, e.g. for Markdown Tables.
 
 ```ts
-import { semanticSnapshot } from "@cronn/element-snapshot";
+import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
 
-test("matches element snapshot", async ({ page }) => {
-  await expect(semanticSnapshot(page.getByRole("main"))).toMatchJsonFile();
+const expect = defineElementSnapshotMatchers();
+
+test("matches semantic snapshot", async ({ page }) => {
+  await expect(page.getByRole("main")).toMatchSemanticSnapshotFile();
 });
 ```
 
 **Output:**
 
-```json [matches_element_snapshot.json]
+```json [matches_semantic_snapshot.json]
 {
   "main": [
     {

--- a/packages/docs/src/playwright/index.md
+++ b/packages/docs/src/playwright/index.md
@@ -35,7 +35,7 @@ yarn add -D @cronn/playwright-file-snapshots
 
 Define the custom matchers (e.g. in `fixtures.ts`):
 
-```ts
+```ts [fixtures.ts]
 import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
 export const expect = defineFileSnapshotMatchers();
@@ -53,9 +53,9 @@ test("matches JSON file", async () => {
 });
 ```
 
-**Output (`matches_JSON_file.json`):**
+**Output:**
 
-```json
+```json [matches_JSON_file.json]
 {
   "value": "expected value"
 }
@@ -75,9 +75,9 @@ test("matches ARIA snapshot", async ({ page }) => {
 });
 ```
 
-**Output (`matches_aria_snapshot.json`):**
+**Output:**
 
-```json
+```json [matches_ARIA_snapshot.json]
 {
   "main": [
     "heading 'List' [level=1]",
@@ -109,9 +109,9 @@ test("matches element snapshot", async ({ page }) => {
 });
 ```
 
-**Output (`̀matches_element_snapshot.json`):**
+**Output:**
 
-```json
+```json [matches_element_snapshot.json]
 {
   "main": [
     {

--- a/packages/docs/src/playwright/writing-tests.md
+++ b/packages/docs/src/playwright/writing-tests.md
@@ -15,9 +15,9 @@ test("value is expected value", async () => {
 });
 ```
 
-**Output (`value_is_expected_value.json`):**
+**Output:**
 
-```json
+```json [value_is_expected_value.json]
 {
   "value": "expected value"
 }
@@ -43,9 +43,9 @@ test("date is masked", async () => {
 });
 ```
 
-**Output (`value_is_expected_value.json`):**
+**Output:**
 
-```json
+```json [date_is_masked.json]
 {
   "date": "[DATE]"
 }
@@ -119,7 +119,7 @@ test("match values using soft assertions", async () => {
 
 ### Enabling Soft Assertions for All Matchers
 
-```ts
+```ts [fixtures.ts]
 export const expect = defineFileSnapshotMatchers().configure({
   soft: true,
 });

--- a/packages/docs/src/vitest/configuration.md
+++ b/packages/docs/src/vitest/configuration.md
@@ -2,7 +2,7 @@
 
 Configuration options can be passed when registering the file matchers in the setup file:
 
-```ts
+```ts [vitest-setup.ts]
 registerFileSnapshotMatchers({
   testDir: "src",
 });

--- a/packages/docs/src/vitest/file-matchers/to-match-json-file.md
+++ b/packages/docs/src/vitest/file-matchers/to-match-json-file.md
@@ -10,9 +10,9 @@ test("value is expected value", () => {
 });
 ```
 
-**Output (`value_is_expected_value.json`):**
+**Output:**
 
-```json
+```json [value_is_expected_value.json]
 {
   "value": "expected value"
 }
@@ -30,9 +30,9 @@ test("includes undefined properties", () => {
 });
 ```
 
-**Output (`includes_undefined_properties.json`):**
+**Output:**
 
-```json
+```json [includes_undefined_properties.json]
 {
   "name": "Alice",
   "age": {

--- a/packages/docs/src/vitest/file-matchers/to-match-markdown-table-file.md
+++ b/packages/docs/src/vitest/file-matchers/to-match-markdown-table-file.md
@@ -24,9 +24,9 @@ test("matches Markdown table", () => {
 });
 ```
 
-**Output (`matches_Markdown_table.md`):**
+**Output:**
 
-```md
+```md [matches_Markdown_table.md]
 | input   | output   |
 | ------- | -------- |
 | input 1 | output 1 |
@@ -50,9 +50,9 @@ test("matches Markdown table from records", () => {
 });
 ```
 
-**Output (`matches_Markdown_table_from_records.md`):**
+**Output:**
 
-```md
+```md [matches_Markdown_table_from_records.md]
 | input   | output   |
 | ------- | -------- |
 | input 1 | output 1 |

--- a/packages/docs/src/vitest/file-matchers/to-match-text-file.md
+++ b/packages/docs/src/vitest/file-matchers/to-match-text-file.md
@@ -10,9 +10,9 @@ test("value is expected value", () => {
 });
 ```
 
-**Output (`value_is_expected_value.txt`):**
+**Output:**
 
-```
+```[value_is_expected_value.txt]
 expected value
 ```
 
@@ -21,14 +21,14 @@ expected value
 Use `fileExtension` to store snapshots with a different file extension:
 
 ```ts
-test("html snapshot", () => {
+test("HTML snapshot", () => {
   expect("<main>Hello World</main>").toMatchTextFile({ fileExtension: "html" });
 });
 ```
 
-**Output (`html_snapshot.html`):**
+**Output:**
 
-```html
+```html [HTML_snapshot.html]
 <main>Hello World</main>
 ```
 

--- a/packages/docs/src/vitest/getting-started.md
+++ b/packages/docs/src/vitest/getting-started.md
@@ -24,7 +24,7 @@ yarn add -D @cronn/vitest-file-snapshots
 
 Import the custom matchers in your `vitest-setup.ts`:
 
-```ts
+```ts [vitest-setup.ts]
 import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
 registerFileSnapshotMatchers();
@@ -34,7 +34,7 @@ registerFileSnapshotMatchers();
 
 If you don't have a setup file in your project, create it and add it to your `vitest.config.ts`:
 
-```ts
+```ts [vitest.config.ts]
 {
   test: {
     setupFiles: ["vitest-setup.ts"];
@@ -46,7 +46,7 @@ If you don't have a setup file in your project, create it and add it to your `vi
 
 To get proper typings in TypeScript, add the `vitest-setup.ts` to your `tsconfig.json`:
 
-```json
+```json [tsconfig.json]
 {
   "include": ["vitest-setup.ts"]
 }
@@ -56,7 +56,7 @@ To get proper typings in TypeScript, add the `vitest-setup.ts` to your `tsconfig
 
 All file snapshots are generated to `/data/test`. The golden masters are stored in `/data/test/validation`, which should be under version control. The file snapshots generated for test runs are stored under `/data/test/output` and should be ignored:
 
-```
+```[.gitignore]
 # file snapshots
 /data/test/output
 ```

--- a/packages/docs/src/vitest/index.md
+++ b/packages/docs/src/vitest/index.md
@@ -37,7 +37,7 @@ yarn add -D @cronn/vitest-file-snapshots
 
 Register the custom matchers in your `vitest-setup.ts`:
 
-```ts
+```ts [vitest-setup.ts]
 import { registerFileSnapshotMatchers } from "@cronn/vitest-file-snapshots/register";
 
 registerFileSnapshotMatchers();
@@ -51,9 +51,9 @@ test("value is expected value", () => {
 });
 ```
 
-**Output (`value_is_expected_value.json`):**
+**Output:**
 
-```json
+```json [value_is_expected_value.json]
 {
   "value": "expected value"
 }

--- a/packages/docs/src/vitest/writing-tests.md
+++ b/packages/docs/src/vitest/writing-tests.md
@@ -16,9 +16,9 @@ test("value is expected value", () => {
 });
 ```
 
-**Output (`value_is_expected_value.json`):**
+**Output:**
 
-```json
+```json [value_is_expected_value.json]
 {
   "value": "expected value"
 }
@@ -42,9 +42,9 @@ test("maps values to string", () => {
 });
 ```
 
-**Output (`maps_values_to_string.json`):**
+**Output:**
 
-```json
+```json [maps_values_to_string.json]
 {
   "boolean": "true",
   "positiveNumber": "1",
@@ -70,9 +70,9 @@ test("date is masked", () => {
 });
 ```
 
-**Output (`date_is_masked.json`):**
+**Output:**
 
-```json
+```json [date_is_masked.json]
 {
   "date": "[DATE]"
 }
@@ -123,17 +123,17 @@ test("value is mapped", () => {
 });
 ```
 
-**Output 1 (`value_is_mapped_before.json`):**
+**Output 1:**
 
-```json
+```json [value_is_mapped_before.json]
 {
   "value": "value"
 }
 ```
 
-**Output 2 (`value_is_mapped_after.json`):**
+**Output 2:**
 
-```json
+```json [value_is_mapped_after.json]
 {
   "value": "mapped value"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ catalogs:
     vitepress:
       specifier: 2.0.0-alpha.17
       version: 2.0.0-alpha.17
+    vitepress-plugin-group-icons:
+      specifier: 1.7.5
+      version: 1.7.5
     vitest:
       specifier: 4.1.5
       version: 4.1.5
@@ -416,6 +419,9 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 2.0.0-alpha.17(@types/node@24.12.2)(jiti@2.6.1)(oxc-minify@0.128.0)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
+      vitepress-plugin-group-icons:
+        specifier: 'catalog:'
+        version: 1.7.5(vite@8.0.8)
 
   packages/element-snapshot:
     dependencies:
@@ -771,6 +777,9 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
@@ -961,11 +970,20 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/logos@1.2.11':
+    resolution: {integrity: sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==}
+
   '@iconify-json/simple-icons@1.2.72':
     resolution: {integrity: sha512-wkcixntHvaCoqPqerGrNFcHQ3Yx1ux4ZkhscCDK0DEHpP62XCH+cxq1HTsRjbUiQl/M9K8bj03HF6Wgn5iE2rQ==}
 
+  '@iconify-json/vscode-icons@1.2.49':
+    resolution: {integrity: sha512-kPSF7NYMEepp/YxM/Sz9AK3+8tEb4Vz94N67OH4Xw9PetIs6at9iETVAAD47WR1sV+VkQo+Uynd8IMKw3J5NGQ==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -3458,6 +3476,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   import-without-cache@0.3.3:
     resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
     engines: {node: '>=20.19.0'}
@@ -4885,6 +4906,14 @@ packages:
       yaml:
         optional: true
 
+  vitepress-plugin-group-icons@1.7.5:
+    resolution: {integrity: sha512-QzcroUuIiVKyXpmEiiHVbfRTQIy9Zbwxpk5JC/zavO8mavitwumz2RZWlwTchMCCHducYyPptkYvXvdnNUWkog==}
+    peerDependencies:
+      vite: '>=8.0.5'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vitepress@2.0.0-alpha.17:
     resolution: {integrity: sha512-Z3VPUpwk/bHYqt1uMVOOK1/4xFiWQov1GNc2FvMdz6kvje4JRXEOngVI9C+bi5jeedMSHiA4dwKkff1NCvbZ9Q==}
     hasBin: true
@@ -5047,6 +5076,11 @@ packages:
 snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.1
 
   '@arethetypeswrong/core@0.18.2':
     dependencies:
@@ -5327,11 +5361,25 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/logos@1.2.11':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify-json/simple-icons@1.2.72':
     dependencies:
       '@iconify/types': 2.0.0
 
+  '@iconify-json/vscode-icons@1.2.49':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@inquirer/external-editor@1.0.3(@types/node@24.12.2)':
     dependencies:
@@ -7988,6 +8036,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  import-meta-resolve@4.2.0: {}
+
   import-without-cache@0.3.3: {}
 
   imurmurhash@0.1.4: {}
@@ -9401,6 +9451,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
+
+  vitepress-plugin-group-icons@1.7.5(vite@8.0.8):
+    dependencies:
+      '@iconify-json/logos': 1.2.11
+      '@iconify-json/vscode-icons': 1.2.49
+      '@iconify/utils': 3.1.3
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3)
 
   vitepress@2.0.0-alpha.17(@types/node@24.12.2)(jiti@2.6.1)(oxc-minify@0.128.0)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ catalog:
   "turbo": 2.9.7
   "typescript-eslint": 8.59.0
   "vitepress": 2.0.0-alpha.17
+  "vitepress-plugin-group-icons": 1.7.5
   "vitest": 4.1.5
   "yaml": 2.8.3
 dedupePeers: true


### PR DESCRIPTION
This PR adds the `vitepress-plugin-group-icons` package to the documentation setup. Besides adding file-specific items to code blocks, it also enables labeling code non-grouped blocks with a file name, making the overall documentation more readable.

<img width="709" height="442" alt="image" src="https://github.com/user-attachments/assets/9d0d549c-4a7b-4ded-8e70-ceed3a3e1a45" />