### PR TITLE
Fix release job

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "knip:check": "knip",
     "knip:fix": "knip --fix",
     "prepublishOnly": "pnpm turbo run ci",
-    "release": "pnpm turbo run build && pnpm changeset publish",
+    "release": "pnpm turbo run build && pnpm publish --recursive --access=public --provenance",
     "version": "pnpm changeset version && pnpm turbo run format:fix"
   },
   "devDependencies": {


### PR DESCRIPTION
`changeset publish` uses `npm info` even though `pnpm` is configured via `devEngines.packageManager`. This leads to an error when running the `release` job in CI.

To avoid the problem, we directly run `pnpm publish`.