### PR TITLE
feat(element-snapshot): Infer role of `th` elements without `scope` attribute

### DIFF
--- a/.changeset/late-experts-report.md
+++ b/.changeset/late-experts-report.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Infer role of `th` elements without `scope` attribute for simple table structures

--- a/.changeset/rich-horses-rule.md
+++ b/.changeset/rich-horses-rule.md
@@ -1,0 +1,5 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Support `colgroup` and `rowgroup` scope attributes for table headers

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/alternating_cell_types.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/alternating_cell_types.json
@@ -1,0 +1,53 @@
+[
+  {
+    "role": "table",
+    "attributes": {},
+    "children": [
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "rowheader",
+                "name": "Header Cell 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Header Cell 1"
+                  }
+                ]
+              },
+              {
+                "role": "cell",
+                "name": "Data Cell 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Data Cell 1"
+                  }
+                ]
+              },
+              {
+                "role": "columnheader",
+                "name": "Header Cell 2",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Header Cell 2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/colgroup_header.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/colgroup_header.json
@@ -1,0 +1,115 @@
+[
+  {
+    "role": "table",
+    "attributes": {},
+    "children": [
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "columnheader",
+                "name": "Column Header 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Header 1"
+                  }
+                ]
+              },
+              {
+                "role": "columnheader",
+                "name": "Column Group Header",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Group Header"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "columnheader",
+                "name": "Column Header 2",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Header 2"
+                  }
+                ]
+              },
+              {
+                "role": "columnheader",
+                "name": "Column Header 3",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Header 3"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "cell",
+                "name": "Body Cell 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Body Cell 1"
+                  }
+                ]
+              },
+              {
+                "role": "cell",
+                "name": "Body Cell 2",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Body Cell 2"
+                  }
+                ]
+              },
+              {
+                "role": "cell",
+                "name": "Body Cell 3",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Body Cell 3"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/implicit_column_header.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/implicit_column_header.json
@@ -1,0 +1,42 @@
+[
+  {
+    "role": "table",
+    "attributes": {},
+    "children": [
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "columnheader",
+                "name": "Column Header 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Header 1"
+                  }
+                ]
+              },
+              {
+                "role": "columnheader",
+                "name": "Column Header 2",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Column Header 2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/implicit_row_header.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/implicit_row_header.json
@@ -1,0 +1,42 @@
+[
+  {
+    "role": "table",
+    "attributes": {},
+    "children": [
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "rowheader",
+                "name": "Row Header",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Row Header"
+                  }
+                ]
+              },
+              {
+                "role": "cell",
+                "name": "Data Cell",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Data Cell"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/table/rowgroup_header.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/table/rowgroup_header.json
@@ -1,0 +1,59 @@
+[
+  {
+    "role": "table",
+    "attributes": {},
+    "children": [
+      {
+        "role": "rowgroup",
+        "attributes": {},
+        "children": [
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "rowheader",
+                "name": "Row Group Header",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Row Group Header"
+                  }
+                ]
+              },
+              {
+                "role": "cell",
+                "name": "Body Cell 1",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Body Cell 1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "role": "row",
+            "attributes": {},
+            "children": [
+              {
+                "role": "cell",
+                "name": "Body Cell 2",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Body Cell 2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/src/browser/element.ts
+++ b/packages/element-snapshot/src/browser/element.ts
@@ -155,3 +155,18 @@ function isHiddenElement(element: SnapshotTargetElement): boolean {
     cssStyles.visibility === "collapse"
   );
 }
+
+export function getNextElementSibling(
+  element: Element,
+): SnapshotTargetElement | null {
+  const nextElementSibling = element.nextElementSibling;
+  if (nextElementSibling === null) {
+    return null;
+  }
+
+  if (!isSupportedElement(nextElementSibling)) {
+    return getNextElementSibling(nextElementSibling);
+  }
+
+  return nextElementSibling;
+}

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -2,7 +2,7 @@ import type { CommonInputRole, InputRole } from "../types/elements/input";
 import type { ElementRole } from "../types/role";
 
 import { isContainerRole } from "./container";
-import { hasRoleSpecificSnapshot } from "./element";
+import { getNextElementSibling, hasRoleSpecificSnapshot } from "./element";
 import { roleSelector, selectorList } from "./selector";
 import type { ElementTagName, SnapshotTargetElement } from "./types";
 import { getElementTagName, isWithinElement } from "./utils";
@@ -211,8 +211,36 @@ function resolveTableHeaderCellRole(
     case "rowgroup":
       return "rowheader";
     default:
-      return undefined;
+      return resolveTableHeaderCellRoleFromContext(element);
   }
+}
+
+function resolveTableHeaderCellRoleFromContext(
+  element: HTMLTableCellElement,
+): "columnheader" | "rowheader" | undefined {
+  const row: HTMLTableRowElement | null = element.closest("tr");
+  if (row === null) {
+    return undefined;
+  }
+
+  const nextElementSibling = getNextElementSibling(element);
+  if (
+    row.rowIndex === 0 &&
+    (nextElementSibling === null ||
+      resolveElementRole(nextElementSibling) === "columnheader")
+  ) {
+    return "columnheader";
+  }
+
+  if (
+    element.cellIndex === 0 &&
+    nextElementSibling !== null &&
+    resolveElementRole(nextElementSibling) === "cell"
+  ) {
+    return "rowheader";
+  }
+
+  return undefined;
 }
 
 function isWithinTableOrGrid(element: Element): boolean {

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -205,8 +205,10 @@ function resolveTableHeaderCellRole(
 
   switch (scope) {
     case "col":
+    case "colgroup":
       return "columnheader";
     case "row":
+    case "rowgroup":
       return "rowheader";
     default:
       return undefined;

--- a/packages/element-snapshot/tests/elements/table.spec.ts
+++ b/packages/element-snapshot/tests/elements/table.spec.ts
@@ -118,6 +118,55 @@ test("rowgroup header", async ({ page }) => {
   );
 });
 
+test("implicit column header", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <table>
+        <tr>
+          <th>Column Header 1</th>
+          <th>Column Header 2</th>
+        </tr>
+      </table>
+    `,
+  );
+});
+
+test("implicit row header", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <table>
+        <tr>
+          <th>Row Header</th>
+          <td>Data Cell</td>
+        </tr>
+      </table>
+    `,
+  );
+});
+
+/**
+ * This test just asserts the behavior of the simplified cell scope resolver.
+ * The used algorithm does not fulfill the HTML specification for complex and invalid cases.
+ *
+ * @see https://html.spec.whatwg.org/multipage/tables.html#forming-a-table
+ */
+test("alternating cell types", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <table>
+        <tr>
+          <th>Header Cell 1</th>
+          <td>Data Cell 1</td>
+          <th>Header Cell 2</th>
+        </tr>
+      </table>
+    `,
+  );
+});
+
 test("empty table", async ({ page }) => {
   await matchRawElementSnapshot(page, html`<table></table>`);
 });

--- a/packages/element-snapshot/tests/elements/table.spec.ts
+++ b/packages/element-snapshot/tests/elements/table.spec.ts
@@ -72,6 +72,52 @@ test("sorted columnheader", async ({ page }) => {
   );
 });
 
+test("colgroup header", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <table>
+        <colgroup></colgroup>
+        <colgroup span="2"></colgroup>
+        <thead>
+          <tr>
+            <th scope="col" rowspan="2">Column Header 1</th>
+            <th scope="colgroup" colspan="2">Column Group Header</th>
+          </tr>
+          <tr>
+            <th scope="col">Column Header 2</th>
+            <th scope="col">Column Header 3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Body Cell 1</td>
+            <td>Body Cell 2</td>
+            <td>Body Cell 3</td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  );
+});
+
+test("rowgroup header", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <table>
+        <tr>
+          <th scope="rowgroup" rowspan="2">Row Group Header</th>
+          <td>Body Cell 1</th>
+        </tr>
+        <tr>
+          <td>Body Cell 2</td>
+        </tr>
+      </table>
+    `,
+  );
+});
+
 test("empty table", async ({ page }) => {
   await matchRawElementSnapshot(page, html`<table></table>`);
 });


### PR DESCRIPTION
This PR extends role resolution for table header cells:
- **Support `colgroup` and `rowgroup` scope values** — previously only `scope="col"` and `scope="row"` were recognized. `scope="colgroup"` now resolves to `columnheader` and `scope="rowgroup"` to `rowheader`, matching the HTML spec.
- **Infer role when `scope` is omitted** — when a `<th>` has no `scope` attribute, the role is now derived from its position in the table:
  - First row + next sibling is also a header (or none) → `columnheader`
  - First cell in a row + next sibling is a regular cell → `rowheader`
  - Otherwise the role stays unresolved (previous behavior)

This is a simplified algorithm for the common case. The test "alternating cell types" documents the behavior for an invalid order of cell types, which is not intended to provide correct results for the current algorithm.

Closes #341 