### PR TITLE
feat(playwright-file-snapshots): Add `defineConfig` helper for shared configuration

### DIFF
--- a/.changeset/famous-walls-laugh.md
+++ b/.changeset/famous-walls-laugh.md
@@ -1,0 +1,5 @@
+---
+"@cronn/playwright-file-snapshots": minor
+---
+
+Add `defineConfig` helper for shared configuration

--- a/packages/docs/src/playwright/getting-started.md
+++ b/packages/docs/src/playwright/getting-started.md
@@ -46,12 +46,30 @@ test("matches JSON file", async () => {
 If you are already using other custom matchers, you can merge them with the validation file matchers:
 
 ```ts [fixtures.ts]
-import { mergeExpects, mergeTests } from "@playwright/test";
-
+import { mergeExpects } from "@playwright/test";
 import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
 
 const expect = mergeExpects(defineFileSnapshotMatchers(), otherExpect);
 ```
+
+> [!TIP]
+> When using other custom matchers which are based on `@cronn/playwright-file-snapshots` (e.g. [`@cronn/element-snapshot`](/playwright/element-snapshots/)), you can use the `defineConfig` helper to define a shared configuration:
+>
+> ```ts [fixtures.ts]
+> import { mergeExpects } from "@playwright/test";
+>
+> import { defineFileSnapshotMatchers } from "@cronn/playwright-file-snapshots";
+> import { defineElementSnapshotMatchers } from "@cronn/element-snapshot";
+>
+> const config = definedConfig({
+>   updateDelay: 1000,
+> });
+>
+> const expect = mergeExpects(
+>   defineFileSnapshotMatchers(config),
+>   defineElementSnapshotMatchers(config),
+> );
+> ```
 
 ## Configure `.gitignore`
 

--- a/packages/playwright-file-snapshots/src/__tests__/config-utils.test.ts
+++ b/packages/playwright-file-snapshots/src/__tests__/config-utils.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "vitest";
+
+import type { PlaywrightValidationFileMatcherConfig } from "../matchers/types";
+import { defineConfig } from "../utils/config";
+
+test("return original options as matcher config", () => {
+  const options: PlaywrightValidationFileMatcherConfig = {
+    validationDir: "/validation",
+    outputDir: "/output",
+    updateDelay: 1000,
+  };
+
+  expect(defineConfig(options)).toBe(options);
+});

--- a/packages/playwright-file-snapshots/src/index.ts
+++ b/packages/playwright-file-snapshots/src/index.ts
@@ -10,6 +10,7 @@ export type {
   PlaywrightValidationFileMatcherConfig,
   PlaywrightValidationFileMatchers,
 } from "./matchers/types";
+export { defineConfig } from "./utils/config";
 
 export {
   maskPattern,

--- a/packages/playwright-file-snapshots/src/utils/config.ts
+++ b/packages/playwright-file-snapshots/src/utils/config.ts
@@ -1,0 +1,14 @@
+import type { PlaywrightValidationFileMatcherConfig } from "../matchers/types";
+
+/**
+ * Defines a configuration object for the Playwright validation file matcher.
+ * This function provides type safety and IntelliSense support for configuration options.
+ *
+ * @param {PlaywrightValidationFileMatcherConfig} options - The configuration options for the Playwright validation file matcher
+ * @return {PlaywrightValidationFileMatcherConfig} The same configuration object passed as input, with proper typing applied
+ */
+export function defineConfig(
+  options: PlaywrightValidationFileMatcherConfig,
+): PlaywrightValidationFileMatcherConfig {
+  return options;
+}


### PR DESCRIPTION
Export `defineConfig utility function to enable type-safe configuration sharing across multiple matcher implementations, with updated documentation showing usage with `@cronn/element-snapshot.

Closes #436 