### PR TITLE
feat(element snapshot): Support `aria-current` in link snapshots

### DIFF
--- a/.changeset/aria-current-link-attribute.md
+++ b/.changeset/aria-current-link-attribute.md
@@ -1,0 +1,7 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add `aria-current` attribute support to link snapshots
+
+Link snapshots now include a `current` attribute when `aria-current` is set. Supported values are `true`, `false`, `page` and `step`.

--- a/packages/element-snapshot/data/integration-test/validation/elements/link/aria-current_attribute.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/link/aria-current_attribute.json
@@ -1,0 +1,57 @@
+[
+  {
+    "role": "link",
+    "name": "Page",
+    "attributes": {
+      "url": "/page",
+      "current": "page"
+    },
+    "children": [
+      {
+        "role": "text",
+        "name": "Page"
+      }
+    ]
+  },
+  {
+    "role": "link",
+    "name": "Step",
+    "attributes": {
+      "url": "/step",
+      "current": "step"
+    },
+    "children": [
+      {
+        "role": "text",
+        "name": "Step"
+      }
+    ]
+  },
+  {
+    "role": "link",
+    "name": "True",
+    "attributes": {
+      "url": "/true",
+      "current": true
+    },
+    "children": [
+      {
+        "role": "text",
+        "name": "True"
+      }
+    ]
+  },
+  {
+    "role": "link",
+    "name": "False",
+    "attributes": {
+      "url": "/false"
+    },
+    "children": [
+      {
+        "role": "text",
+        "name": "False"
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/unit-test/validation/attribute-parsers/boolean_attribute.md
+++ b/packages/element-snapshot/data/unit-test/validation/attribute-parsers/boolean_attribute.md
@@ -1,7 +1,7 @@
 | value   | parsedValue |
 | ------- | ----------- |
 | null    | undefined   |
+| true    | true        |
+| false   | undefined   |
 | "true"  | true        |
 | "false" | undefined   |
-| "enum"  | "enum"      |
-| "other" | undefined   |

--- a/packages/element-snapshot/data/unit-test/validation/attribute-parsers/boolean_or_enum_attribute.md
+++ b/packages/element-snapshot/data/unit-test/validation/attribute-parsers/boolean_or_enum_attribute.md
@@ -1,0 +1,7 @@
+| value | parsedValue |
+| ----- | ----------- |
+| null  | undefined   |
+| true  | true        |
+| false | undefined   |
+| enum  | enum        |
+| other | undefined   |

--- a/packages/element-snapshot/data/unit-test/validation/attribute-parsers/enum_attribute.md
+++ b/packages/element-snapshot/data/unit-test/validation/attribute-parsers/enum_attribute.md
@@ -1,7 +1,5 @@
 | value   | parsedValue |
 | ------- | ----------- |
 | null    | undefined   |
-| "true"  | true        |
-| "false" | undefined   |
 | "enum"  | "enum"      |
 | "other" | undefined   |

--- a/packages/element-snapshot/data/unit-test/validation/attribute-parsers/numeric_attribute.md
+++ b/packages/element-snapshot/data/unit-test/validation/attribute-parsers/numeric_attribute.md
@@ -1,0 +1,5 @@
+| value   | parsedValue |
+| ------- | ----------- |
+| null    | undefined   |
+| "4711"  | 4711        |
+| "value" | undefined   |

--- a/packages/element-snapshot/data/unit-test/validation/attribute-parsers/string_attribute.md
+++ b/packages/element-snapshot/data/unit-test/validation/attribute-parsers/string_attribute.md
@@ -1,0 +1,5 @@
+| value   | parsedValue |
+| ------- | ----------- |
+| null    | undefined   |
+| "value" | "value"     |
+| ""      | undefined   |

--- a/packages/element-snapshot/src/__tests__/attribute-parsers.test.ts
+++ b/packages/element-snapshot/src/__tests__/attribute-parsers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "vitest";
 
+import { Table } from "@cronn/lib-file-snapshots";
+
 import {
   booleanAttribute,
   enumAttribute,
+  booleanOrEnumAttribute,
   numericAttribute,
   stringAttribute,
 } from "../browser/attribute";
@@ -73,4 +76,18 @@ describe("enum attribute", () => {
   test("when value is null, returns undefined", () => {
     expect(enumAttribute(null, new Set<string>())).toBeUndefined();
   });
+});
+
+test("boolean or enum attribute", () => {
+  const inputValues = [null, "true", "false", "enum", "other"];
+  const enumValues = new Set(["enum"]);
+
+  expect(
+    Table.fromRecords(
+      inputValues.map((value) => ({
+        value,
+        parsedValue: booleanOrEnumAttribute(value, enumValues),
+      })),
+    ),
+  ).toMatchMarkdownTableFile();
 });

--- a/packages/element-snapshot/src/__tests__/attribute-parsers.test.ts
+++ b/packages/element-snapshot/src/__tests__/attribute-parsers.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "vitest";
+import { expect, test } from "vitest";
 
-import { Table } from "@cronn/lib-file-snapshots";
+import { Table, type TableCell } from "@cronn/vitest-file-snapshots";
 
 import {
   booleanAttribute,
@@ -10,72 +10,39 @@ import {
   stringAttribute,
 } from "../browser/attribute";
 
-describe("string attribute", () => {
-  test("when value is non-empty string, returns value", () => {
-    expect(stringAttribute("value")).toBe("value");
-  });
+test("string attribute", () => {
+  const inputValues = [null, "value", ""];
 
-  test("when value is empty string, returns undefined", () => {
-    expect(stringAttribute(null)).toBeUndefined();
-  });
-
-  test("when value is null, returns undefined", () => {
-    expect(stringAttribute(null)).toBeUndefined();
-  });
+  expect(
+    attributeParserTable(inputValues, stringAttribute),
+  ).toMatchMarkdownTableFile();
 });
 
-describe("boolean attribute", () => {
-  test("when value is true, returns true", () => {
-    expect(booleanAttribute(true)).toBe(true);
-  });
+test("boolean attribute", () => {
+  const inputValues = [null, true, false, "true", "false"];
 
-  test("when value is 'true', returns true", () => {
-    expect(booleanAttribute("true")).toBe(true);
-  });
-
-  test("when value is false, returns undefined", () => {
-    expect(booleanAttribute(false)).toBeUndefined();
-  });
-
-  test("when value is 'false', returns undefined", () => {
-    expect(booleanAttribute("false")).toBeUndefined();
-  });
-
-  test("when value is null, returns undefined", () => {
-    expect(booleanAttribute("false")).toBeUndefined();
-  });
+  expect(
+    attributeParserTable(inputValues, booleanAttribute),
+  ).toMatchMarkdownTableFile();
 });
 
-describe("numeric attribute", () => {
-  test("when value represents a number, returns numeric value", () => {
-    expect(numericAttribute("4711")).toBe(4711);
-  });
+test("numeric attribute", () => {
+  const inputValues = [null, "4711", "value"];
 
-  test("when value does not represent a number, returns undefined", () => {
-    expect(numericAttribute("value")).toBeUndefined();
-  });
-
-  test("when value is null, returns undefined", () => {
-    expect(numericAttribute(null)).toBeUndefined();
-  });
+  expect(
+    attributeParserTable(inputValues, numericAttribute),
+  ).toMatchMarkdownTableFile();
 });
 
-describe("enum attribute", () => {
-  test("when value exists in enum, returns value", () => {
-    expect(enumAttribute("supported", new Set(["supported"]))).toBe(
-      "supported",
-    );
-  });
+test("enum attribute", () => {
+  const inputValues = [null, "enum", "other"];
+  const enumValues = new Set(["enum"]);
 
-  test("when value does not exist in enum, returns undefined", () => {
-    expect(
-      enumAttribute("unsupported", new Set(["supported"])),
-    ).toBeUndefined();
-  });
-
-  test("when value is null, returns undefined", () => {
-    expect(enumAttribute(null, new Set<string>())).toBeUndefined();
-  });
+  expect(
+    attributeParserTable(inputValues, (value) =>
+      enumAttribute(value, enumValues),
+    ),
+  ).toMatchMarkdownTableFile();
 });
 
 test("boolean or enum attribute", () => {
@@ -83,11 +50,26 @@ test("boolean or enum attribute", () => {
   const enumValues = new Set(["enum"]);
 
   expect(
-    Table.fromRecords(
-      inputValues.map((value) => ({
-        value,
-        parsedValue: booleanOrEnumAttribute(value, enumValues),
-      })),
+    attributeParserTable(inputValues, (value) =>
+      booleanOrEnumAttribute(value, enumValues),
     ),
   ).toMatchMarkdownTableFile();
 });
+
+type AttributeValue = string | boolean | null;
+
+function attributeParserTable<TValue extends AttributeValue>(
+  inputValues: Array<TValue>,
+  attributeParser: (value: TValue) => TableCell,
+): Table {
+  return Table.fromRecords(
+    inputValues.map((value) => ({
+      value: serializeValue(value),
+      parsedValue: serializeValue(attributeParser(value)),
+    })),
+  );
+}
+
+function serializeValue(value: TableCell): TableCell {
+  return typeof value === "string" ? `"${value}"` : value;
+}

--- a/packages/element-snapshot/src/browser/attribute.ts
+++ b/packages/element-snapshot/src/browser/attribute.ts
@@ -30,6 +30,17 @@ export function enumAttribute<TEnum extends string>(
   return value as TEnum;
 }
 
+export function booleanOrEnumAttribute<TEnum extends string>(
+  value: string | null,
+  supportedStringValues: Set<TEnum>,
+): true | TEnum | undefined {
+  if (value === "true" || value === "false") {
+    return booleanAttribute(value);
+  }
+
+  return enumAttribute(value, supportedStringValues);
+}
+
 export function resolveElementReference(
   element: SnapshotTargetElement,
   attributeName: string,

--- a/packages/element-snapshot/src/browser/button.ts
+++ b/packages/element-snapshot/src/browser/button.ts
@@ -1,12 +1,12 @@
-import type { ButtonSnapshot, PressedValue } from "../types/elements/button";
+import type { ButtonSnapshot } from "../types/elements/button";
 
-import { booleanAttribute, enumAttribute } from "./attribute";
+import { booleanAttribute, booleanOrEnumAttribute } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
 import { disableableAttributes } from "./state";
 import type { SnapshotTargetElement } from "./types";
 
-const PRESSED_VALUES = new Set(["true", "mixed", "false"] as const);
+const pressedValues = new Set(["mixed"] as const);
 
 export function snapshotButton(
   element: SnapshotTargetElement,
@@ -17,19 +17,8 @@ export function snapshotButton(
     attributes: {
       ...disableableAttributes(element),
       expanded: booleanAttribute(element.ariaExpanded),
-      pressed: resolvePressedAttribute(element),
+      pressed: booleanOrEnumAttribute(element.ariaPressed, pressedValues),
     },
     children: snapshotChildren(element),
   };
-}
-
-function resolvePressedAttribute(
-  element: SnapshotTargetElement,
-): PressedValue | undefined {
-  const pressed = enumAttribute(element.ariaPressed, PRESSED_VALUES);
-  if (pressed === "mixed") {
-    return pressed;
-  }
-
-  return booleanAttribute(pressed === "true");
 }

--- a/packages/element-snapshot/src/browser/link.ts
+++ b/packages/element-snapshot/src/browser/link.ts
@@ -1,9 +1,11 @@
 import type { LinkAttributes, LinkSnapshot } from "../types/elements/link";
 
-import { stringAttribute } from "./attribute";
+import { booleanOrEnumAttribute, stringAttribute } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
 import type { SnapshotTargetElement } from "./types";
+
+const currentValues = new Set(["page", "step"] as const);
 
 export function snapshotLink(element: SnapshotTargetElement): LinkSnapshot {
   return {
@@ -15,5 +17,8 @@ export function snapshotLink(element: SnapshotTargetElement): LinkSnapshot {
 }
 
 export function linkAttributes(element: SnapshotTargetElement): LinkAttributes {
-  return { url: stringAttribute(element.getAttribute("href")) };
+  return {
+    url: stringAttribute(element.getAttribute("href")),
+    current: booleanOrEnumAttribute(element.ariaCurrent, currentValues),
+  };
 }

--- a/packages/element-snapshot/src/types/elements/button.ts
+++ b/packages/element-snapshot/src/types/elements/button.ts
@@ -11,4 +11,4 @@ interface ButtonAttributes extends DisableableAttributes {
   pressed?: PressedValue;
 }
 
-export type PressedValue = true | "mixed";
+type PressedValue = true | "mixed";

--- a/packages/element-snapshot/src/types/elements/link.ts
+++ b/packages/element-snapshot/src/types/elements/link.ts
@@ -7,4 +7,7 @@ export interface LinkSnapshot extends GenericElementSnapshot<
 
 export interface LinkAttributes {
   url?: string;
+  current?: CurrentValue;
 }
+
+type CurrentValue = true | "page" | "step";

--- a/packages/element-snapshot/tests/elements/link.spec.ts
+++ b/packages/element-snapshot/tests/elements/link.spec.ts
@@ -7,3 +7,15 @@ import { matchRawElementSnapshot } from "../../src/test/fixtures";
 test("HTML link", async ({ page }) => {
   await matchRawElementSnapshot(page, html`<a href="/target">Link</a>`);
 });
+
+test("aria-current attribute", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <a href="/page" aria-current="page">Page</a>
+      <a href="/step" aria-current="step">Step</a>
+      <a href="/true" aria-current="true">True</a>
+      <a href="/false" aria-current="false">False</a>
+    `,
+  );
+});


### PR DESCRIPTION
Link snapshots now include a `current` attribute when [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current) is set. Supported values are `true`, `false`, `page` and `step`.

Support for other element types and attribute values will be added as needed.