### PR TITLE
chore(deps): Update turbo to v2.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/aria-snapshot/package.json
+++ b/packages/aria-snapshot/package.json
@@ -74,6 +74,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -46,6 +46,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/element-snapshot/package.json
+++ b/packages/element-snapshot/package.json
@@ -76,6 +76,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/lib-file-snapshots/package.json
+++ b/packages/lib-file-snapshots/package.json
@@ -69,6 +69,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/meta-updater/package.json
+++ b/packages/meta-updater/package.json
@@ -48,6 +48,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/meta-updater/src/update-package-json.ts
+++ b/packages/meta-updater/src/update-package-json.ts
@@ -23,7 +23,6 @@ export function updatePackageJson(
     license: "Apache-2.0",
     repository: defineRepository(context),
     homepage: manifest.homepage ?? "https://github.com/cronn/file-snapshots",
-    packageManager: `pnpm@${PNPM_VERSION}`,
     engines: {
       node: "^20 || ^22 || >=24",
     },

--- a/packages/playwright-file-snapshots/package.json
+++ b/packages/playwright-file-snapshots/package.json
@@ -80,6 +80,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/shared-configs/package.json
+++ b/packages/shared-configs/package.json
@@ -62,6 +62,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -53,6 +53,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/packages/vitest-file-snapshots/package.json
+++ b/packages/vitest-file-snapshots/package.json
@@ -82,6 +82,5 @@
   },
   "engines": {
     "node": "^20 || ^22 || >=24"
-  },
-  "packageManager": "pnpm@11.7.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ catalogs:
       specifier: 0.22.3
       version: 0.22.3
     turbo:
-      specifier: 2.10.0
-      version: 2.10.0
+      specifier: 2.10.2
+      version: 2.10.2
     typescript-eslint:
       specifier: 8.62.1
       version: 8.62.1
@@ -326,7 +326,7 @@ importers:
         version: 6.1.3
       turbo:
         specifier: 'catalog:'
-        version: 2.10.0
+        version: 2.10.2
 
   packages/aria-snapshot:
     dependencies:
@@ -2351,33 +2351,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@turbo/darwin-64@2.10.0':
-    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
+  '@turbo/darwin-64@2.10.2':
+    resolution: {integrity: sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.0':
-    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
+  '@turbo/darwin-arm64@2.10.2':
+    resolution: {integrity: sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.0':
-    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
+  '@turbo/linux-64@2.10.2':
+    resolution: {integrity: sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.10.0':
-    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
+  '@turbo/linux-arm64@2.10.2':
+    resolution: {integrity: sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.10.0':
-    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
+  '@turbo/windows-64@2.10.2':
+    resolution: {integrity: sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.0':
-    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
+  '@turbo/windows-arm64@2.10.2':
+    resolution: {integrity: sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg==}
     cpu: [arm64]
     os: [win32]
 
@@ -4769,8 +4769,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo@2.10.0:
-    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
+  turbo@2.10.2:
+    resolution: {integrity: sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==}
     hasBin: true
 
   typanion@3.14.0:
@@ -6964,22 +6964,22 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@turbo/darwin-64@2.10.0':
+  '@turbo/darwin-64@2.10.2':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.0':
+  '@turbo/darwin-arm64@2.10.2':
     optional: true
 
-  '@turbo/linux-64@2.10.0':
+  '@turbo/linux-64@2.10.2':
     optional: true
 
-  '@turbo/linux-arm64@2.10.0':
+  '@turbo/linux-arm64@2.10.2':
     optional: true
 
-  '@turbo/windows-64@2.10.0':
+  '@turbo/windows-64@2.10.2':
     optional: true
 
-  '@turbo/windows-arm64@2.10.0':
+  '@turbo/windows-arm64@2.10.2':
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -9378,14 +9378,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turbo@2.10.0:
+  turbo@2.10.2:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.0
-      '@turbo/darwin-arm64': 2.10.0
-      '@turbo/linux-64': 2.10.0
-      '@turbo/linux-arm64': 2.10.0
-      '@turbo/windows-64': 2.10.0
-      '@turbo/windows-arm64': 2.10.0
+      '@turbo/darwin-64': 2.10.2
+      '@turbo/darwin-arm64': 2.10.2
+      '@turbo/linux-64': 2.10.2
+      '@turbo/linux-arm64': 2.10.2
+      '@turbo/windows-64': 2.10.2
+      '@turbo/windows-arm64': 2.10.2
 
   typanion@3.14.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   "publint": 0.3.21
   "rimraf": 6.1.3
   "tsdown": 0.22.3
-  "turbo": 2.10.0
+  "turbo": 2.10.2
   "typescript-eslint": 8.62.1
   "vitepress": 2.0.0-alpha.17
   "vitepress-plugin-group-icons": 1.7.5


### PR DESCRIPTION
This version adds support for devEngines.packageManager, which enables removing the redundant and deprecated packageManager field.