### PR TITLE
ci: Do not run CI job on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI pipeline
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
pull_request already triggers the CI job, leading to a redundant execution.