### PR TITLE
feat(element-snapshot): Flatten structure of semantic snapshots

### DIFF
--- a/.changeset/eleven-socks-beam.md
+++ b/.changeset/eleven-socks-beam.md
@@ -1,0 +1,27 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Flatten structure of semantic snapshots
+
+**Breaking change**: Semantic snapshots now have a different structure. To update existing snapshots, use Playwright's `--update-snapshots` flag.
+
+Before:
+
+```json
+{
+  "heading": {
+    "name": "Heading",
+    "level": 1
+  }
+}
+```
+
+After:
+
+```json
+{
+  "heading": "Heading",
+  "level": 1
+}
+```

--- a/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
+++ b/packages/docs/src/playwright/element-snapshots/semantic-snapshots.md
@@ -28,10 +28,8 @@ test("matches semantic snapshot", async ({ page }) => {
 {
   "main": [
     {
-      "heading": {
-        "name": "List",
-        "level": 1
-      }
+      "heading": "List",
+      "level": 1
     },
     {
       "list": [

--- a/packages/element-snapshot/README.md
+++ b/packages/element-snapshot/README.md
@@ -52,10 +52,8 @@ test("matches element snapshot", async ({ page }) => {
 {
   "main": [
     {
-      "heading": {
-        "name": "List",
-        "level": 1
-      }
+      "heading": "List",
+      "level": 1
     },
     {
       "list": [

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/exclude_options_minimal_case.json
@@ -5,10 +5,8 @@
   {
     "listbox": [
       {
-        "option": {
-          "name": "Option 1",
-          "selected": true
-        }
+        "option": "Option 1",
+        "selected": true
       },
       {
         "option": "Option 2"

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/excludes_empty_options.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/excludes_empty_options.json
@@ -1,6 +1,4 @@
 {
-  "combobox": {
-    "name": "Combobox",
-    "value": "Value"
-  }
+  "combobox": "Combobox",
+  "value": "Value"
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/excludes_options_by_default.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/excludes_options_by_default.json
@@ -1,6 +1,4 @@
 {
-  "combobox": {
-    "name": "Select",
-    "value": "Option 1"
-  }
+  "combobox": "Select",
+  "value": "Option 1"
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/include_options_minimal_case.json
@@ -1,27 +1,21 @@
 [
   {
-    "combobox": {
-      "name": "Combobox",
-      "options": [
-        {
-          "option": {
-            "name": "Option 1",
-            "selected": true
-          }
-        },
-        {
-          "option": "Option 2"
-        }
-      ]
-    }
+    "combobox": "Combobox",
+    "options": [
+      {
+        "option": "Option 1",
+        "selected": true
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
   },
   {
     "listbox": [
       {
-        "option": {
-          "name": "Option 1",
-          "selected": true
-        }
+        "option": "Option 1",
+        "selected": true
       },
       {
         "option": "Option 2"

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_from_referenced_listbox.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_from_referenced_listbox.json
@@ -1,28 +1,22 @@
 [
   {
-    "combobox": {
-      "name": "Combobox",
-      "value": "Option 1",
-      "options": [
-        {
-          "option": {
-            "name": "Option 1",
-            "selected": true
-          }
-        },
-        {
-          "option": "Option 2"
-        }
-      ]
-    }
+    "combobox": "Combobox",
+    "value": "Option 1",
+    "options": [
+      {
+        "option": "Option 1",
+        "selected": true
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
   },
   {
     "listbox": [
       {
-        "option": {
-          "name": "Option 1",
-          "selected": true
-        }
+        "option": "Option 1",
+        "selected": true
       },
       {
         "option": "Option 2"

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_of_HTML_select.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_of_HTML_select.json
@@ -1,17 +1,13 @@
 {
-  "combobox": {
-    "name": "Select",
-    "value": "Option 1",
-    "options": [
-      {
-        "option": {
-          "name": "Option 1",
-          "selected": true
-        }
-      },
-      {
-        "option": "Option 2"
-      }
-    ]
-  }
+  "combobox": "Select",
+  "value": "Option 1",
+  "options": [
+    {
+      "option": "Option 1",
+      "selected": true
+    },
+    {
+      "option": "Option 2"
+    }
+  ]
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/flattens_defined_attributes.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/flattens_defined_attributes.json
@@ -1,7 +1,5 @@
 {
-  "textbox": {
-    "name": "Input Name",
-    "value": "Input Value",
-    "readonly": true
-  }
+  "textbox": "Input Name",
+  "value": "Input Value",
+  "readonly": true
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_attributes_and_children_includes_children_property.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_attributes_and_children_includes_children_property.json
@@ -1,10 +1,9 @@
 {
-  "link": {
-    "url": "/target",
-    "children": [
-      {
-        "img": "Image"
-      }
-    ]
-  }
+  "link": "",
+  "url": "/target",
+  "children": [
+    {
+      "img": "Image"
+    }
+  ]
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_name_and_children_includes_children_property.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_name_and_children_includes_children_property.json
@@ -1,16 +1,12 @@
 {
-  "region": {
-    "name": "Heading",
-    "children": [
-      {
-        "heading": {
-          "name": "Heading",
-          "level": 2
-        }
-      },
-      {
-        "paragraph": "Paragraph"
-      }
-    ]
-  }
+  "region": "Heading",
+  "children": [
+    {
+      "heading": "Heading",
+      "level": 2
+    },
+    {
+      "paragraph": "Paragraph"
+    }
+  ]
 }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_only_children_resolves_value_to_children.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_element_has_only_children_resolves_value_to_children.json
@@ -1,10 +1,8 @@
 {
   "main": [
     {
-      "heading": {
-        "name": "Headline",
-        "level": 1
-      }
+      "heading": "Headline",
+      "level": 1
     },
     {
       "paragraph": "Paragraph"

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_name_equals_children_excludes_children.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_name_equals_children_excludes_children.json
@@ -1,6 +1,4 @@
 {
-  "heading": {
-    "name": "Heading",
-    "level": 1
-  }
+  "heading": "Heading",
+  "level": 1
 }

--- a/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
+++ b/packages/element-snapshot/src/playwright/semantic-snapshot-transformer.ts
@@ -92,8 +92,7 @@ export class SemanticSnapshotTransformer {
     }
 
     const { role, name, attributes, children } = normalizedSnapshot;
-    return this.transformedSnapshot(role, {
-      name: name.length === 0 ? undefined : name,
+    return this.transformedSnapshot(role, name, {
       ...attributes,
       children: children.length === 0 ? undefined : children,
     });
@@ -185,7 +184,11 @@ export class SemanticSnapshotTransformer {
     return attributes[name];
   }
 
-  private transformedSnapshot(role: ElementRole, content: unknown): unknown {
-    return { [role]: content };
+  private transformedSnapshot(
+    role: ElementRole,
+    nameOrContent: unknown,
+    additionalProperties?: Record<string, unknown>,
+  ): unknown {
+    return { [role]: nameOrContent, ...additionalProperties };
   }
 }


### PR DESCRIPTION
Simplify the semantic snapshot output format by flattening objects. Instead of nesting additional properties below the role name, place them besides the role name. This reduces nesting and improves readability.

**Breaking change**: Semantic snapshots now have a different structure. To update existing snapshots, use Playwright's `--update-snapshots` flag.

Before:
```json
{
  "heading": {
    "name": "Heading",
    "level": 1
  }
}
```

After:
```json
{
  "heading": "Heading",
  "level": 1
}
```
