### PR TITLE
feat(element-snapshot): Add support for elements with `role="combobox"`

### DIFF
--- a/.changeset/role-based-combobox.md
+++ b/.changeset/role-based-combobox.md
@@ -1,0 +1,7 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add support for arbitrary elements with `role="combobox"`
+
+Previously only `<select>`, `<input role="combobox">` and `<button role="combobox">` were snapshotted as a combobox, while any other element with `role="combobox"` was silently dropped together with its subtree. Such elements are now snapshotted as well, using their accessible text content as `value` — which covers component libraries rendering a combobox as a `<div>`, e.g. the Material UI `Select`. In addition, `aria-expanded` is now reported as the `expanded` attribute of a combobox.

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_input-based_combobox.json
@@ -12,6 +12,7 @@
         "name": "Combobox",
         "attributes": {
           "value": "Input Value",
+          "expanded": true,
           "options": [
             {
               "role": "option",

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_role-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-state/expanded_role-based_combobox.json
@@ -1,9 +1,19 @@
 [
   {
+    "role": "label",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Combobox"
+      }
+    ]
+  },
+  {
     "role": "combobox",
     "name": "Combobox",
     "attributes": {
-      "value": "Button Value",
+      "value": "Option 1",
       "expanded": true,
       "options": [
         {

--- a/packages/element-snapshot/data/integration-test/validation/elements/input-type/role-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/input-type/role-based_combobox.json
@@ -1,10 +1,19 @@
 [
   {
+    "role": "label",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Combobox"
+      }
+    ]
+  },
+  {
     "role": "combobox",
     "name": "Combobox",
     "attributes": {
-      "value": "Button Value",
-      "expanded": true,
+      "value": "Option 1",
       "options": [
         {
           "role": "option",
@@ -27,6 +36,19 @@
             {
               "role": "text",
               "name": "Option 2"
+            }
+          ]
+        },
+        {
+          "role": "option",
+          "name": "Option 3",
+          "attributes": {
+            "disabled": true
+          },
+          "children": [
+            {
+              "role": "text",
+              "name": "Option 3"
             }
           ]
         }
@@ -59,6 +81,19 @@
           {
             "role": "text",
             "name": "Option 2"
+          }
+        ]
+      },
+      {
+        "role": "option",
+        "name": "Option 3",
+        "attributes": {
+          "disabled": true
+        },
+        "children": [
+          {
+            "role": "text",
+            "name": "Option 3"
           }
         ]
       }

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_of_role-based_combobox.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/combobox-options/includes_options_of_role-based_combobox.json
@@ -1,0 +1,27 @@
+[
+  {
+    "combobox": "Combobox",
+    "value": "Option 1",
+    "expanded": true,
+    "options": [
+      {
+        "option": "Option 1",
+        "selected": true
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
+  },
+  {
+    "listbox": [
+      {
+        "option": "Option 1",
+        "selected": true
+      },
+      {
+        "option": "Option 2"
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/src/browser/button.ts
+++ b/packages/element-snapshot/src/browser/button.ts
@@ -1,9 +1,9 @@
 import type { ButtonSnapshot } from "../types/elements/button";
 
-import { booleanAttribute, booleanOrEnumAttribute } from "./attribute";
+import { booleanOrEnumAttribute } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveAccessibleName } from "./name";
-import { disableableAttributes } from "./state";
+import { disableableAttributes, expandableAttributes } from "./state";
 import type { SnapshotTargetElement } from "./types";
 
 const pressedValues = new Set(["mixed"] as const);
@@ -16,7 +16,7 @@ export function snapshotButton(
     name: resolveAccessibleName(element),
     attributes: {
       ...disableableAttributes(element),
-      expanded: booleanAttribute(element.ariaExpanded),
+      ...expandableAttributes(element),
       pressed: booleanOrEnumAttribute(element.ariaPressed, pressedValues),
     },
     children: snapshotChildren(element),

--- a/packages/element-snapshot/src/browser/combobox.ts
+++ b/packages/element-snapshot/src/browser/combobox.ts
@@ -5,11 +5,13 @@ import { resolveElementReference } from "./attribute";
 import { snapshotChildren } from "./children";
 import { resolveInputValue, snapshotCommonInputAttributes } from "./input";
 import { resolveAccessibleName } from "./name";
-import { disableableAttributes, selectableAttributes } from "./state";
+import {
+  disableableAttributes,
+  expandableAttributes,
+  selectableAttributes,
+} from "./state";
 import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
-
-type ComboboxElement = HTMLSelectElement | HTMLInputElement | HTMLButtonElement;
 
 export function snapshotCombobox(
   element: SnapshotTargetElement,
@@ -26,38 +28,31 @@ export function snapshotCombobox(
     attributes: {
       value: resolveValue(element),
       ...snapshotCommonInputAttributes(element),
+      ...expandableAttributes(element),
       options,
     },
     children: [],
   };
 }
 
-function isCombobox(
-  element: SnapshotTargetElement,
-): element is ComboboxElement {
+function isCombobox(element: SnapshotTargetElement): boolean {
+  // a <select> without an explicit role has the implicit role "combobox"
   if (element instanceof HTMLSelectElement) {
     return element.role === null || element.role === "combobox";
   }
 
-  if (
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLButtonElement
-  ) {
-    return element.role === "combobox";
-  }
-
-  return false;
+  return element.role === "combobox";
 }
 
 function resolveValue(
-  element: ComboboxElement,
+  element: SnapshotTargetElement,
 ): string | Array<string> | undefined {
-  if (element instanceof HTMLButtonElement) {
-    return resolveAccessibleTextContent(element);
-  }
-
   if (element instanceof HTMLInputElement) {
     return resolveInputValue(element);
+  }
+
+  if (!(element instanceof HTMLSelectElement)) {
+    return resolveAccessibleTextContent(element);
   }
 
   const selectedLabels = Array.from(element.selectedOptions).map(
@@ -75,7 +70,9 @@ function resolveValue(
   return selectedLabels;
 }
 
-function snapshotOptions(element: ComboboxElement): Array<OptionSnapshot> {
+function snapshotOptions(
+  element: SnapshotTargetElement,
+): Array<OptionSnapshot> {
   const optionsContainer = resolveOptionsContainer(element);
   if (optionsContainer === null) {
     return [];
@@ -84,7 +81,9 @@ function snapshotOptions(element: ComboboxElement): Array<OptionSnapshot> {
   return filterByRole("option", snapshotChildren(optionsContainer));
 }
 
-function resolveOptionsContainer(element: ComboboxElement): HTMLElement | null {
+function resolveOptionsContainer(
+  element: SnapshotTargetElement,
+): HTMLElement | null {
   if (element instanceof HTMLSelectElement) {
     return element;
   }

--- a/packages/element-snapshot/src/browser/input.ts
+++ b/packages/element-snapshot/src/browser/input.ts
@@ -11,12 +11,6 @@ import { resolveInputRole } from "./role";
 import { inputStateAttributes } from "./state";
 import type { SnapshotTargetElement } from "./types";
 
-type InputElement =
-  | HTMLInputElement
-  | HTMLTextAreaElement
-  | HTMLSelectElement
-  | HTMLButtonElement;
-
 export function snapshotInput(
   element: SnapshotTargetElement,
 ): InputSnapshot | null {
@@ -65,7 +59,7 @@ function snapshotTextareaElement(element: HTMLTextAreaElement): InputSnapshot {
 }
 
 export function snapshotCommonInputAttributes(
-  element: InputElement,
+  element: SnapshotTargetElement,
 ): CommonInputAttributes {
   return {
     ...discribableAttributes(element),
@@ -99,10 +93,12 @@ function resolveChecked(
   return element.checked ? true : undefined;
 }
 
-function resolvePlaceholder(element: InputElement): string | undefined {
+function resolvePlaceholder(
+  element: SnapshotTargetElement,
+): string | undefined {
   if (
-    element instanceof HTMLSelectElement ||
-    element instanceof HTMLButtonElement
+    !(element instanceof HTMLInputElement) &&
+    !(element instanceof HTMLTextAreaElement)
   ) {
     return undefined;
   }

--- a/packages/element-snapshot/src/browser/state.ts
+++ b/packages/element-snapshot/src/browser/state.ts
@@ -1,5 +1,6 @@
 import type {
   DisableableAttributes,
+  ExpandableAttributes,
   InputStateAttributes,
   SelectableAttributes,
 } from "../types/attributes";
@@ -33,6 +34,14 @@ export function selectableAttributes(
 
   return {
     selected: selected ?? booleanAttribute(element.ariaSelected),
+  };
+}
+
+export function expandableAttributes(
+  element: SnapshotTargetElement,
+): ExpandableAttributes {
+  return {
+    expanded: booleanAttribute(element.ariaExpanded),
   };
 }
 

--- a/packages/element-snapshot/src/types/attributes.ts
+++ b/packages/element-snapshot/src/types/attributes.ts
@@ -6,6 +6,10 @@ export interface SelectableAttributes {
   selected?: boolean;
 }
 
+export interface ExpandableAttributes {
+  expanded?: boolean;
+}
+
 export interface DiscribableAttributes {
   description?: string;
 }

--- a/packages/element-snapshot/src/types/elements/button.ts
+++ b/packages/element-snapshot/src/types/elements/button.ts
@@ -1,4 +1,7 @@
-import type { DisableableAttributes } from "../attributes";
+import type {
+  DisableableAttributes,
+  ExpandableAttributes,
+} from "../attributes";
 import type { GenericElementSnapshot } from "../snapshot";
 
 export interface ButtonSnapshot extends GenericElementSnapshot<
@@ -6,8 +9,7 @@ export interface ButtonSnapshot extends GenericElementSnapshot<
   ButtonAttributes
 > {}
 
-interface ButtonAttributes extends DisableableAttributes {
-  expanded?: boolean;
+interface ButtonAttributes extends DisableableAttributes, ExpandableAttributes {
   pressed?: PressedValue;
 }
 

--- a/packages/element-snapshot/src/types/elements/input.ts
+++ b/packages/element-snapshot/src/types/elements/input.ts
@@ -1,6 +1,7 @@
 import type {
   DisableableAttributes,
   DiscribableAttributes,
+  ExpandableAttributes,
   InputStateAttributes,
   SelectableAttributes,
 } from "../attributes";
@@ -37,7 +38,8 @@ export interface ComboboxSnapshot extends GenericElementSnapshot<
   ComboboxAttributes
 > {}
 
-interface ComboboxAttributes extends CommonInputAttributes {
+interface ComboboxAttributes
+  extends CommonInputAttributes, ExpandableAttributes {
   value?: string | Array<string>;
   options: Array<OptionSnapshot>;
 }

--- a/packages/element-snapshot/tests/elements/input-state.spec.ts
+++ b/packages/element-snapshot/tests/elements/input-state.spec.ts
@@ -139,3 +139,25 @@ test("expanded button-based combobox", async ({ page }) => {
     `,
   );
 });
+
+test("expanded role-based combobox", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <label for="combobox">Combobox</label>
+      <div
+        id="combobox"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-controls="options"
+        aria-expanded="true"
+      >
+        Option 1
+      </div>
+      <ul id="options" role="listbox">
+        <li role="option" aria-selected="true">Option 1</li>
+        <li role="option" aria-selected="false">Option 2</li>
+      </ul>
+    `,
+  );
+});

--- a/packages/element-snapshot/tests/elements/input-type.spec.ts
+++ b/packages/element-snapshot/tests/elements/input-type.spec.ts
@@ -195,6 +195,30 @@ test("input-based combobox", async ({ page }) => {
   );
 });
 
+test("role-based combobox", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <label for="combobox">Combobox</label>
+      <div
+        id="combobox"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        aria-controls="options"
+        aria-expanded="false"
+      >
+        Option 1
+      </div>
+      <ul id="options" role="listbox">
+        <li role="option" aria-selected="true">Option 1</li>
+        <li role="option" aria-selected="false">Option 2</li>
+        <li role="option" aria-disabled="true">Option 3</li>
+      </ul>
+    `,
+  );
+});
+
 test("button-based combobox", async ({ page }) => {
   await matchRawElementSnapshot(
     page,

--- a/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
+++ b/packages/element-snapshot/tests/semantic-snapshot/combobox-options.spec.ts
@@ -58,6 +58,31 @@ test("includes options from referenced listbox", async ({ page }) => {
   });
 });
 
+test("includes options of role-based combobox", async ({ page }) => {
+  const bodyLocator = await setupSnapshotTest(
+    page,
+    html`
+      <div
+        role="combobox"
+        aria-label="Combobox"
+        aria-haspopup="listbox"
+        aria-controls="options"
+        aria-expanded="true"
+      >
+        Option 1
+      </div>
+      <ul id="options" role="listbox">
+        <li role="option" aria-selected="true">Option 1</li>
+        <li role="option" aria-selected="false">Option 2</li>
+      </ul>
+    `,
+  );
+
+  await expect(bodyLocator).toMatchSemanticSnapshotFile({
+    includeComboboxOptions: true,
+  });
+});
+
 test("excludes empty options", async ({ page }) => {
   const bodyLocator = await setupSnapshotTest(
     page,


### PR DESCRIPTION
Closes #503

## Changes

- Snapshot **arbitrary elements** with an explicit [`role="combobox"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role), using their accessible text content as `value`. Previously only `<select>`, `<input role="combobox">` and `<button role="combobox">` were supported — any other element with that role was silently dropped together with its subtree. This covers component libraries that render a combobox as a `<div>`, e.g. the [Material UI `Select`](https://mui.com/material-ui/react-select/).
- Report `aria-expanded` as the `expanded` attribute of a combobox. This was previously dropped for *all* comboboxes, so the existing `expanded input-based combobox` / `expanded button-based combobox` snapshots did not contain the state their name implies.
- Extract the shared `expanded` handling into `ExpandableAttributes` / `expandableAttributes()`, now used by both `button` and `combobox`.

Resulting snapshot for a `div`-based combobox:

```json
{
  "combobox": "Combobox",
  "value": "Option 1",
  "expanded": true,
  "options": [
    {
      "option": "Option 1",
      "selected": true
    },
    {
      "option": "Option 2"
    }
  ]
}
```

## Notes

The options container is still resolved via `aria-controls` only. Libraries that set `aria-controls` exclusively while the popup is open (such as MUI) therefore yield `options: []` in the collapsed state — unchanged from the current behaviour for button-based comboboxes.