### PR TITLE
feat(element-snapshot): Support `tree` and `treeitem` roles

### DIFF
--- a/.changeset/tree-roles.md
+++ b/.changeset/tree-roles.md
@@ -1,0 +1,9 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add support for elements with `role="tree"` and `role="treeitem"`
+
+Tree widgets were previously dropped from snapshots together with their subtree unless elements with implicit ARIA roles were used. A `tree` is now snapshotted as a named container, and a `treeitem` within a tree reports its ARIA states as `expanded`, `checked`, `selected` and `disabled` attributes. `aria-checked="mixed"` is preserved as `"mixed"`, and nested items wrapped in `role="group"` are snapshotted as children.
+
+See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/empty_tree.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/empty_tree.json
@@ -1,0 +1,7 @@
+[
+  {
+    "role": "tree",
+    "attributes": {},
+    "children": []
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/empty_treeitem.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/empty_treeitem.json
@@ -1,0 +1,13 @@
+[
+  {
+    "role": "tree",
+    "attributes": {},
+    "children": [
+      {
+        "role": "treeitem",
+        "attributes": {},
+        "children": []
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/ignores_treeitem_outside_tree.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/ignores_treeitem_outside_tree.json
@@ -1,0 +1,6 @@
+[
+  {
+    "role": "text",
+    "name": "Treeitem"
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/tree.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/tree.json
@@ -1,0 +1,70 @@
+[
+  {
+    "role": "tree",
+    "name": "Tree",
+    "attributes": {},
+    "children": [
+      {
+        "role": "treeitem",
+        "attributes": {
+          "selected": true,
+          "expanded": true
+        },
+        "children": [
+          {
+            "role": "text",
+            "name": "Fruits"
+          },
+          {
+            "role": "group",
+            "attributes": {},
+            "children": [
+              {
+                "role": "treeitem",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Apple"
+                  }
+                ]
+              },
+              {
+                "role": "treeitem",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Pear"
+                  }
+                ]
+              },
+              {
+                "role": "treeitem",
+                "attributes": {
+                  "disabled": true
+                },
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Banana"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "role": "treeitem",
+        "attributes": {},
+        "children": [
+          {
+            "role": "text",
+            "name": "Vegetables"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/tree.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/tree.json
@@ -6,6 +6,7 @@
     "children": [
       {
         "role": "treeitem",
+        "name": "Fruits",
         "attributes": {
           "selected": true,
           "expanded": true
@@ -21,6 +22,7 @@
             "children": [
               {
                 "role": "treeitem",
+                "name": "Apple",
                 "attributes": {},
                 "children": [
                   {
@@ -31,6 +33,7 @@
               },
               {
                 "role": "treeitem",
+                "name": "Pear",
                 "attributes": {},
                 "children": [
                   {
@@ -41,6 +44,7 @@
               },
               {
                 "role": "treeitem",
+                "name": "Banana",
                 "attributes": {
                   "disabled": true
                 },
@@ -57,6 +61,7 @@
       },
       {
         "role": "treeitem",
+        "name": "Vegetables",
         "attributes": {},
         "children": [
           {

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/tree_with_checkboxes.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/tree_with_checkboxes.json
@@ -1,0 +1,50 @@
+[
+  {
+    "role": "tree",
+    "name": "Tree",
+    "attributes": {},
+    "children": [
+      {
+        "role": "treeitem",
+        "attributes": {
+          "checked": "mixed",
+          "expanded": true
+        },
+        "children": [
+          {
+            "role": "text",
+            "name": "Fruits"
+          },
+          {
+            "role": "group",
+            "attributes": {},
+            "children": [
+              {
+                "role": "treeitem",
+                "attributes": {
+                  "checked": true
+                },
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Apple"
+                  }
+                ]
+              },
+              {
+                "role": "treeitem",
+                "attributes": {},
+                "children": [
+                  {
+                    "role": "text",
+                    "name": "Pear"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/elements/tree/tree_with_checkboxes.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/tree/tree_with_checkboxes.json
@@ -6,6 +6,7 @@
     "children": [
       {
         "role": "treeitem",
+        "name": "Fruits",
         "attributes": {
           "checked": "mixed",
           "expanded": true
@@ -21,6 +22,7 @@
             "children": [
               {
                 "role": "treeitem",
+                "name": "Apple",
                 "attributes": {
                   "checked": true
                 },
@@ -33,6 +35,7 @@
               },
               {
                 "role": "treeitem",
+                "name": "Pear",
                 "attributes": {},
                 "children": [
                   {

--- a/packages/element-snapshot/src/browser/element.ts
+++ b/packages/element-snapshot/src/browser/element.ts
@@ -21,6 +21,7 @@ import { snapshotSeparator } from "./separator";
 import { snapshotTab } from "./tab";
 import { snapshotCellWithRole, snapshotColumnHeader } from "./table";
 import { snapshotTextNode } from "./text";
+import { snapshotTreeItem } from "./tree";
 import type { SnapshotTargetElement, SnapshotTargetNode } from "./types";
 import { getElementTagName } from "./utils";
 
@@ -56,6 +57,7 @@ const ROLE_SNAPSHOTS: Record<NonContainerElementRole, ElementSnapshotFn> = {
   spinbutton: snapshotInput,
   tab: snapshotTab,
   textbox: snapshotInput,
+  treeitem: snapshotTreeItem,
 };
 
 export function snapshotElement(

--- a/packages/element-snapshot/src/browser/name.ts
+++ b/packages/element-snapshot/src/browser/name.ts
@@ -2,7 +2,7 @@ import type { ElementRole } from "../types/role";
 
 import { resolveElementReference, stringAttribute } from "./attribute";
 import { parseElementRole } from "./role";
-import { attributeSelector } from "./selector";
+import { attributeSelector, roleSelector } from "./selector";
 import { resolveAccessibleTextContent } from "./text";
 import type { SnapshotTargetElement } from "./types";
 
@@ -45,6 +45,7 @@ const supportsNamingFromChildContent = new Set<ElementRole>([
 const contextBasedNameResolvers: Array<ContextBasedNameResolver> = [
   resolveImageName,
   resolveLegendName,
+  resolveTreeItemName,
 ];
 
 type ContextBasedNameResolver = (
@@ -133,4 +134,18 @@ function resolveImageName(
   }
 
   return undefined;
+}
+
+function resolveTreeItemName(
+  element: SnapshotTargetElement,
+  role: ElementRole,
+): string | undefined {
+  if (role !== "treeitem") {
+    return undefined;
+  }
+
+  return resolveAccessibleTextContent(
+    element,
+    Array.from(element.querySelectorAll(roleSelector("group"))),
+  );
 }

--- a/packages/element-snapshot/src/browser/role.ts
+++ b/packages/element-snapshot/src/browser/role.ts
@@ -85,6 +85,7 @@ const CONTEXT_DEPENDENT_ROLES: Partial<
   rowheader: isWithinTableRowOrGridRow,
   tab: isWithinTablist,
   term: isWithinDescriptionList,
+  treeitem: isWithinTree,
 };
 
 const INPUT_ROLES: Record<
@@ -292,4 +293,8 @@ function isWithinMenu(element: SnapshotTargetElement): boolean {
 
 function isWithinTablist(element: SnapshotTargetElement): boolean {
   return isWithinElement(element, roleSelector("tablist"));
+}
+
+function isWithinTree(element: SnapshotTargetElement): boolean {
+  return isWithinElement(element, roleSelector("tree"));
 }

--- a/packages/element-snapshot/src/browser/state.ts
+++ b/packages/element-snapshot/src/browser/state.ts
@@ -1,11 +1,12 @@
 import type {
+  CheckableAttributes,
   DisableableAttributes,
   ExpandableAttributes,
   InputStateAttributes,
   SelectableAttributes,
 } from "../types/attributes";
 
-import { booleanAttribute } from "./attribute";
+import { booleanAttribute, booleanOrEnumAttribute } from "./attribute";
 import type { SnapshotTargetElement } from "./types";
 
 export function disableableAttributes(
@@ -42,6 +43,16 @@ export function expandableAttributes(
 ): ExpandableAttributes {
   return {
     expanded: booleanAttribute(element.ariaExpanded),
+  };
+}
+
+const checkedValues = new Set(["mixed"] as const);
+
+export function checkableAttributes(
+  element: SnapshotTargetElement,
+): CheckableAttributes {
+  return {
+    checked: booleanOrEnumAttribute(element.ariaChecked, checkedValues),
   };
 }
 

--- a/packages/element-snapshot/src/browser/tree.ts
+++ b/packages/element-snapshot/src/browser/tree.ts
@@ -1,0 +1,27 @@
+import type { TreeItemSnapshot } from "../types/elements/tree";
+
+import { snapshotChildren } from "./children";
+import { resolveAccessibleName } from "./name";
+import {
+  checkableAttributes,
+  disableableAttributes,
+  expandableAttributes,
+  selectableAttributes,
+} from "./state";
+import type { SnapshotTargetElement } from "./types";
+
+export function snapshotTreeItem(
+  element: SnapshotTargetElement,
+): TreeItemSnapshot {
+  return {
+    role: "treeitem",
+    name: resolveAccessibleName(element),
+    attributes: {
+      ...disableableAttributes(element),
+      ...checkableAttributes(element),
+      ...selectableAttributes(element),
+      ...expandableAttributes(element),
+    },
+    children: snapshotChildren(element),
+  };
+}

--- a/packages/element-snapshot/src/index.ts
+++ b/packages/element-snapshot/src/index.ts
@@ -26,6 +26,7 @@ export type {
   CellSnapshot,
   ColumnHeaderSnapshot,
 } from "./types/elements/table";
+export type { TreeItemSnapshot } from "./types/elements/tree";
 export type {
   ElementSnapshotMatchers,
   MatchMarkdownTableSnapshotFileOptions,

--- a/packages/element-snapshot/src/types/attributes.ts
+++ b/packages/element-snapshot/src/types/attributes.ts
@@ -10,6 +10,12 @@ export interface ExpandableAttributes {
   expanded?: boolean;
 }
 
+export interface CheckableAttributes {
+  checked?: CheckedValue;
+}
+
+type CheckedValue = true | "mixed";
+
 export interface DiscribableAttributes {
   description?: string;
 }

--- a/packages/element-snapshot/src/types/elements/container.ts
+++ b/packages/element-snapshot/src/types/elements/container.ts
@@ -38,6 +38,7 @@ export const CONTAINER_ROLES = new Set([
   "tablist",
   "tabpanel",
   "term",
+  "tree",
 ] as const);
 
 export interface ContainerSnapshot extends GenericElementSnapshot<ContainerRole> {}

--- a/packages/element-snapshot/src/types/elements/tree.ts
+++ b/packages/element-snapshot/src/types/elements/tree.ts
@@ -1,0 +1,19 @@
+import type {
+  CheckableAttributes,
+  DisableableAttributes,
+  ExpandableAttributes,
+  SelectableAttributes,
+} from "../attributes";
+import type { GenericElementSnapshot } from "../snapshot";
+
+export interface TreeItemSnapshot extends GenericElementSnapshot<
+  "treeitem",
+  TreeItemAttributes
+> {}
+
+interface TreeItemAttributes
+  extends
+    CheckableAttributes,
+    DisableableAttributes,
+    ExpandableAttributes,
+    SelectableAttributes {}

--- a/packages/element-snapshot/src/types/role.ts
+++ b/packages/element-snapshot/src/types/role.ts
@@ -18,6 +18,7 @@ export type ElementRole =
   | "region"
   | "separator"
   | "tab"
+  | "treeitem"
   | CellRole
   | ContainerRole
   | DialogRole

--- a/packages/element-snapshot/src/types/snapshot.ts
+++ b/packages/element-snapshot/src/types/snapshot.ts
@@ -16,6 +16,7 @@ import type { SeparatorSnapshot } from "./elements/separator";
 import type { TabSnapshot } from "./elements/tab";
 import type { CellSnapshot, ColumnHeaderSnapshot } from "./elements/table";
 import type { TextSnapshot } from "./elements/text";
+import type { TreeItemSnapshot } from "./elements/tree";
 import type { ElementRole, TextRole } from "./role";
 
 export type NodeRole = ElementRole | TextRole;
@@ -54,4 +55,5 @@ export type ElementSnapshot =
   | TabSnapshot
   | MenuItemSnapshot
   | RadioGroupSnapshot
-  | SeparatorSnapshot;
+  | SeparatorSnapshot
+  | TreeItemSnapshot;

--- a/packages/element-snapshot/tests/elements/tree.spec.ts
+++ b/packages/element-snapshot/tests/elements/tree.spec.ts
@@ -1,0 +1,68 @@
+import test from "@playwright/test";
+
+import { html } from "@cronn/test-utils/playwright";
+
+import { matchRawElementSnapshot } from "../../src/test/fixtures";
+
+test("tree", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <ul role="tree" aria-label="Tree">
+        <li role="treeitem" aria-expanded="true" aria-selected="true">
+          <span>Fruits</span>
+          <ul role="group">
+            <li role="treeitem">Apple</li>
+            <li role="treeitem" aria-selected="false">Pear</li>
+            <li role="treeitem" aria-disabled="true">Banana</li>
+          </ul>
+        </li>
+        <li role="treeitem" aria-expanded="false">
+          <span>Vegetables</span>
+          <ul role="group" hidden>
+            <li role="treeitem">Carrot</li>
+          </ul>
+        </li>
+      </ul>
+    `,
+  );
+});
+
+test("tree with checkboxes", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <ul role="tree" aria-label="Tree">
+        <li role="treeitem" aria-expanded="true" aria-checked="mixed">
+          <span>Fruits</span>
+          <ul role="group">
+            <li role="treeitem" aria-checked="true">Apple</li>
+            <li role="treeitem" aria-checked="false">Pear</li>
+          </ul>
+        </li>
+      </ul>
+    `,
+  );
+});
+
+test("empty tree", async ({ page }) => {
+  await matchRawElementSnapshot(page, html`<ul role="tree"></ul>`);
+});
+
+test("empty treeitem", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`
+      <ul role="tree">
+        <li role="treeitem"></li>
+      </ul>
+    `,
+  );
+});
+
+test("ignores treeitem outside tree", async ({ page }) => {
+  await matchRawElementSnapshot(
+    page,
+    html`<div role="treeitem">Treeitem</div>`,
+  );
+});


### PR DESCRIPTION
Closes #502

Adds support for the ARIA [`tree`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role) and [`treeitem`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treeitem_role) roles, which were previously dropped from snapshots together with their subtree.

## Changes

- `tree` is registered as a container role, so it is snapshotted with its accessible name and children.
- New `snapshotTreeitem` serializer for `treeitem`, valid only within a `tree` (`CONTEXT_DEPENDENT_ROLES`, analogous to `menuitem`/`tab`). Nested items wrapped in `role="group"` are covered, since the tree ancestor is resolved via `closest()`.
- `treeitem` reports `expanded`, `checked`, `selected` and `disabled`. `aria-checked="mixed"` is preserved as `"mixed"`; `false` values collapse to `undefined` as everywhere else in the package.

`aria-level`, `aria-setsize` and `aria-posinset` are not reported, as the nesting of the snapshot already conveys that information. A `treeitem` is not named from its child content either, because that would merge the labels of all nested items into the parent's name; `aria-label` and `aria-labelledby` are honoured as usual.