### PR TITLE
feat(element-snapshot): Add support for snapshotting `Page` targets

### DIFF
--- a/.changeset/large-words-lead.md
+++ b/.changeset/large-words-lead.md
@@ -1,0 +1,7 @@
+---
+"@cronn/element-snapshot": minor
+---
+
+Add support for snapshotting `Page` targets
+
+When a Page is passed as target to `rawSnapshot`, `semanticSnapshot` or `expect.toMatchSemanticSnapshotFile`, the snapshot covers the `<body>` of the page.

--- a/packages/element-snapshot/data/integration-test/validation/elements/body/HTML_body.json
+++ b/packages/element-snapshot/data/integration-test/validation/elements/body/HTML_body.json
@@ -1,0 +1,12 @@
+[
+  {
+    "role": "main",
+    "attributes": {},
+    "children": [
+      {
+        "role": "text",
+        "name": "Content"
+      }
+    ]
+  }
+]

--- a/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_target_is_page_snapshots_body.json
+++ b/packages/element-snapshot/data/integration-test/validation/semantic-snapshot/transformer/when_target_is_page_snapshots_body.json
@@ -1,0 +1,3 @@
+{
+  "main": "Content"
+}

--- a/packages/element-snapshot/src/playwright/snapshot.ts
+++ b/packages/element-snapshot/src/playwright/snapshot.ts
@@ -1,6 +1,7 @@
-import type { Locator } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 import type { NodeSnapshot } from "../types/snapshot";
+import type { PlaywrightTarget } from "../types/utils";
 import type { FilterPredicate } from "../utils/filter";
 
 import { ElementSnapshotProxy } from "./proxy";
@@ -38,15 +39,15 @@ export interface SemanticSnapshotOptions {
  * This function creates a raw snapshot of the DOM element identified by the locator
  * and transforms it into a semantic representation using the provided options.
  *
- * @param locator - The Locator instance that identifies the DOM element to snapshot
+ * @param target - The Page or Locator instance that identifies the DOM element to snapshot
  * @param options - Optional configuration settings for controlling the snapshot behavior
  * @return A promise that resolves to the semantic snapshot
  */
 export async function semanticSnapshot(
-  locator: Locator,
+  target: PlaywrightTarget,
   options?: SemanticSnapshotOptions,
 ): Promise<unknown> {
-  const snapshot = await rawSnapshot(locator);
+  const snapshot = await rawSnapshot(target);
   return new SemanticSnapshotTransformer(options).transform(snapshot);
 }
 
@@ -56,13 +57,18 @@ export async function semanticSnapshot(
  * Returns an array of node snapshots representing the current state of the matched elements
  * in the DOM, including their properties, attributes, and structure.
  *
- * @param locator - The Locator instance used to identify the target element to snapshot
+ * @param target - The Page or Locator instance used to identify the target element to snapshot
  * @return A promise that resolves to an array of NodeSnapshot objects representing the captured element
  */
 export async function rawSnapshot(
-  locator: Locator,
+  target: PlaywrightTarget,
 ): Promise<Array<NodeSnapshot>> {
+  const locator = isPage(target) ? target.locator("body") : target;
   return await new ElementSnapshotProxy(locator.page()).snapshotElement(
     locator,
   );
+}
+
+function isPage(target: PlaywrightTarget): target is Page {
+  return "goto" in target && typeof target.goto === "function";
 }

--- a/packages/element-snapshot/src/types/matchers.ts
+++ b/packages/element-snapshot/src/types/matchers.ts
@@ -8,9 +8,11 @@ import type {
 import type { MarkdownTableSnapshotOptions } from "../playwright/markdown-table";
 import type { SemanticSnapshotOptions } from "../playwright/snapshot";
 
+import type { PlaywrightTarget } from "./utils";
+
 export interface ElementSnapshotMatchers {
   toMatchSemanticSnapshotFile: (
-    actual: Locator,
+    actual: PlaywrightTarget,
     options?: MatchSemanticSnapshotFileOptions,
   ) => Promise<MatcherReturnType>;
   toMatchMarkdownTableSnapshotFile: (

--- a/packages/element-snapshot/src/types/utils.ts
+++ b/packages/element-snapshot/src/types/utils.ts
@@ -1,1 +1,5 @@
+import type { Locator, Page } from "@playwright/test";
+
 export type SetValues<TSet> = TSet extends Set<infer TValue> ? TValue : never;
+
+export type PlaywrightTarget = Page | Locator;

--- a/packages/element-snapshot/tests/elements/body.spec.ts
+++ b/packages/element-snapshot/tests/elements/body.spec.ts
@@ -1,0 +1,22 @@
+import test from "@playwright/test";
+
+import { html, setupSnapshotTest } from "@cronn/test-utils/playwright";
+
+import { rawSnapshot } from "../../src";
+import { expect } from "../../src/test/fixtures";
+
+test("HTML body", async ({ page }) => {
+  await setupSnapshotTest(
+    page,
+    html`
+      <head>
+        <title>Title</title>
+      </head>
+      <body>
+        <main>Content</main>
+      </body>
+    `,
+  );
+
+  await expect(await rawSnapshot(page)).toMatchJsonFile();
+});

--- a/packages/element-snapshot/tests/semantic-snapshot/transformer.spec.ts
+++ b/packages/element-snapshot/tests/semantic-snapshot/transformer.spec.ts
@@ -114,3 +114,19 @@ test("when element has attributes and children, includes children property", asy
 
   await expect(bodyLocator).toMatchSemanticSnapshotFile();
 });
+
+test("when target is page, snapshots body", async ({ page }) => {
+  await setupSnapshotTest(
+    page,
+    html`
+      <head>
+        <title>Title</title>
+      </head>
+      <body>
+        <main>Content</main>
+      </body>
+    `,
+  );
+
+  await expect(page).toMatchSemanticSnapshotFile();
+});


### PR DESCRIPTION
When a `Page` is passed as target, the snapshot covers the `<body>` of the page.

This is a quality-of-life extension which enables directly passing `Page` instances to `rawSnapshot`, `semanticSnapshot` and `expect.toMatchSemanticSnapshotFile` in addition to `Locator` instances.

```ts
// Before
expect(page.locator("body")).toMatchSemanticSnapshotFile();

// After
expect(page).toMatchSemanticSnapshotFile();
```